### PR TITLE
Remove leading 'x' from repository name

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,8 +1,8 @@
-#+TITLE: xScheme
+#+TITLE: Exercism Scheme Track
 #+AUTHOR: Jason Lewis
 
 [[https://gitter.im/exercism/xscheme][https://badges.gitter.im/Join%20Chat.svg]]
-[[https://travis-ci.org/exercism/xscheme][https://travis-ci.org/exercism/xscheme.svg?branch=master]]
+[[https://travis-ci.org/exercism/scheme][https://travis-ci.org/exercism/scheme.svg?branch=master]]
 
 Exercism exercises in the Scheme Programming Language
 

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "slug": "scheme",
   "language": "Scheme",
-  "repository": "https://github.com/exercism/xscheme",
+  "repository": "https://github.com/exercism/scheme",
   "active": true,
   "exercises": [
     {


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

The repository itself has already been renamed. GitHub redirects from
the old name to the new name, so we do not have to rush to fix links to
the old repository name, though we should update them for the sake of
clarity.

See exercism/meta#1