### PR TITLE
Reformat the configs using the new configlet fmt command

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,149 +1,119 @@
 {
-  "language": "Scheme",
   "active": true,
   "exercises": [
     {
-      "uuid": "f2936612-edc4-44f9-a403-c60f7c6486e4",
+      "core": false,
+      "difficulty": 1,
       "slug": "hello-world",
-      "core": false,
+      "topics": null,
       "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-
-      ]
+      "uuid": "f2936612-edc4-44f9-a403-c60f7c6486e4"
     },
     {
-      "uuid": "ce513303-471b-459a-bcf1-6c69f4d83ae7",
+      "core": false,
+      "difficulty": 1,
       "slug": "hamming",
-      "core": false,
+      "topics": null,
       "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-
-      ]
+      "uuid": "ce513303-471b-459a-bcf1-6c69f4d83ae7"
     },
     {
-      "uuid": "b94548df-3b35-4ce1-80c7-36179d2b3b86",
+      "core": false,
+      "difficulty": 1,
       "slug": "leap",
-      "core": false,
+      "topics": null,
       "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-
-      ]
+      "uuid": "b94548df-3b35-4ce1-80c7-36179d2b3b86"
     },
     {
-      "uuid": "397d9cfc-43f9-4c57-bc55-5c94ae8f532e",
+      "core": false,
+      "difficulty": 1,
       "slug": "grains",
-      "core": false,
+      "topics": null,
       "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-
-      ]
+      "uuid": "397d9cfc-43f9-4c57-bc55-5c94ae8f532e"
     },
     {
-      "uuid": "4cf6697c-ad9e-426c-a2d8-6c3695812421",
+      "core": false,
+      "difficulty": 1,
       "slug": "bob",
-      "core": false,
+      "topics": null,
       "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-
-      ]
+      "uuid": "4cf6697c-ad9e-426c-a2d8-6c3695812421"
     },
     {
-      "uuid": "9f13b913-a650-4cbf-a392-4b5614e1aa2a",
+      "core": false,
+      "difficulty": 1,
       "slug": "raindrops",
-      "core": false,
+      "topics": null,
       "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-
-      ]
+      "uuid": "9f13b913-a650-4cbf-a392-4b5614e1aa2a"
     },
     {
-      "uuid": "26bf9c24-ba92-473e-9270-8964f1bf71f2",
+      "core": false,
+      "difficulty": 1,
       "slug": "rna-transcription",
-      "core": false,
+      "topics": null,
       "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-
-      ]
+      "uuid": "26bf9c24-ba92-473e-9270-8964f1bf71f2"
     },
     {
-      "uuid": "62a5a71c-a9eb-416b-809c-c862a4828e8b",
+      "core": false,
+      "difficulty": 1,
       "slug": "robot-name",
-      "core": false,
+      "topics": null,
       "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-
-      ]
+      "uuid": "62a5a71c-a9eb-416b-809c-c862a4828e8b"
     },
     {
-      "uuid": "8ed74044-2361-459e-aca5-abd73ed5c1cb",
+      "core": false,
+      "difficulty": 1,
       "slug": "phone-number",
-      "core": false,
+      "topics": null,
       "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-
-      ]
+      "uuid": "8ed74044-2361-459e-aca5-abd73ed5c1cb"
     },
     {
-      "uuid": "c550055c-4bd5-478b-8e91-94347a314aef",
+      "core": false,
+      "difficulty": 1,
       "slug": "anagram",
-      "core": false,
+      "topics": null,
       "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-
-      ]
+      "uuid": "c550055c-4bd5-478b-8e91-94347a314aef"
     },
     {
-      "uuid": "d72cf2c3-9f30-4df1-a69b-04c638bb2426",
+      "core": false,
+      "difficulty": 1,
       "slug": "nucleotide-count",
-      "core": false,
+      "topics": null,
       "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-
-      ]
+      "uuid": "d72cf2c3-9f30-4df1-a69b-04c638bb2426"
     },
     {
-      "uuid": "a3c7a4d2-ba08-47c9-a88e-2311ad02d945",
+      "core": false,
+      "difficulty": 1,
       "slug": "difference-of-squares",
-      "core": false,
+      "topics": null,
       "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-
-      ]
+      "uuid": "a3c7a4d2-ba08-47c9-a88e-2311ad02d945"
     },
     {
-      "uuid": "903374d2-8155-4fe3-bf90-5b6359c7b5cc",
+      "core": false,
+      "difficulty": 1,
       "slug": "list-ops",
-      "core": false,
+      "topics": null,
       "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-
-      ]
+      "uuid": "903374d2-8155-4fe3-bf90-5b6359c7b5cc"
     },
     {
-      "uuid": "5b44ccd4-b1f4-4b86-89c8-f1dec5905ccb",
-      "slug": "scrabble-score",
       "core": false,
-      "unlocked_by": null,
       "difficulty": 1,
-      "topics": [
-
-      ]
+      "slug": "scrabble-score",
+      "topics": null,
+      "unlocked_by": null,
+      "uuid": "5b44ccd4-b1f4-4b86-89c8-f1dec5905ccb"
     }
   ],
-  "foregone": [
-
-  ]
+  "foregone": [],
+  "language": "Scheme"
 }

--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -1,25 +1,25 @@
 {
+  "docs_url": "https://github.com/exercism/docs/blob/master/maintaining-a-track/maintainer-configuration.md",
   "maintainers": [
     {
-      "github_username": "achengs",
-      "show_on_website": false,
       "alumnus": false,
-      "name": null,
+      "avatar_url": null,
       "bio": null,
+      "github_username": "achengs",
       "link_text": null,
       "link_url": null,
-      "avatar_url": null
+      "name": null,
+      "show_on_website": false
     },
     {
-      "github_username": "yurrriq",
-      "show_on_website": false,
       "alumnus": false,
-      "name": null,
+      "avatar_url": null,
       "bio": null,
+      "github_username": "yurrriq",
       "link_text": null,
       "link_url": null,
-      "avatar_url": null
+      "name": null,
+      "show_on_website": false
     }
-  ],
-  "docs_url": "https://github.com/exercism/docs/blob/master/maintaining-a-track/maintainer-configuration.md"
+  ]
 }


### PR DESCRIPTION
FYI @yurrriq - we added a `fmt` command to configlet to help us keep some of the grunt work scriptable without adding noise. That means adding a somewhat noisy PR to fix the formatting the first time around.

I'm going to go ahead and merge this one straight off the bat so I can help @wwest4 get their PR sorted out.