### PR TITLE
Fix naming in scrabble-score-test

### DIFF
--- a/exercises/scrabble-score/scrabble-score-test.scm
+++ b/exercises/scrabble-score/scrabble-score-test.scm
@@ -8,7 +8,7 @@
 (add-to-load-path (dirname (current-filename)))
 (use-modules (scrabble-score))
 
-(test-begin "hello-world")
+(test-begin "scrabble-score")
 
 (test-assert "a is worth one point"
              (equal? (score "a")
@@ -54,4 +54,4 @@
              (equal? (score "")
                      0))
 
-(test-end "hello-world")
+(test-end "scrabble-score")


### PR DESCRIPTION
This looks like a copy-paste-error from hello-world.