### PR TITLE
difference-of-squares: renamed square-of-sums to square-of-sum

### DIFF
--- a/exercises/difference-of-squares/difference-of-squares-test.scm
+++ b/exercises/difference-of-squares/difference-of-squares-test.scm
@@ -10,33 +10,33 @@
 
 (test-begin "difference-of-squares")
 
-(test-eqv "square-of-sums-to-5"
+(test-eqv "square-of-sum-to-5"
           225
-          (square-of-sums 5))
+          (square-of-sum 5))
 (test-eqv "sum-of-squares-to-5"
           55
           (sum-of-squares 5))
-(test-eqv "difference of-sums-to-5"
+(test-eqv "difference-of-squares-to-5"
           170
           (difference 5))
 
-(test-eqv "square-of-sums-to-10"
+(test-eqv "square-of-sum-to-10"
           3025
-          (square-of-sums 10))
+          (square-of-sum 10))
 (test-eqv "sum-of-squares-to-10"
           385
           (sum-of-squares 10))
-(test-eqv "difference of-sums-to-10"
+(test-eqv "difference-of-squares-to-10"
           2640
           (difference 10))
 
-(test-eqv "square-of-sums-to-100"
+(test-eqv "square-of-sum-to-100"
           25502500
-          (square-of-sums 100))
+          (square-of-sum 100))
 (test-eqv "sum-of-squares-to-100"
           338350
           (sum-of-squares 100))
-(test-eqv "difference of-sums-to-100"
+(test-eqv "difference-of-squares-to-100"
           25164150
           (difference 100))
 

--- a/exercises/difference-of-squares/example.scm
+++ b/exercises/difference-of-squares/example.scm
@@ -1,6 +1,6 @@
 (define-module (squares)
   #:export (sum-of-squares
-            square-of-sums
+            square-of-sum
             difference)
   #:autoload (srfi srfi-1) (reduce iota))
 
@@ -9,11 +9,11 @@
   (lambda (n)
     (reduce + 0 (map (lambda (i) (expt i 2)) (iota n 1)))))
 
-(define square-of-sums
+(define square-of-sum
   (lambda (n)
     (expt (reduce + 0 (iota n 1)) 2)))
 
 (define difference
   (lambda (n)
-    (- (square-of-sums n)
+    (- (square-of-sum n)
        (sum-of-squares n))))

--- a/exercises/difference-of-squares/squares.scm
+++ b/exercises/difference-of-squares/squares.scm
@@ -1,5 +1,5 @@
 (define-module (squares)
   #:export (sum-of-squares
-            square-of-sums
+            square-of-sum
             difference)
   #:autoload (srfi srfi-1) (reduce iota))


### PR DESCRIPTION
In exercise "difference-of-squares", renamed `square-of-sums` to `square-of-sum`. Also renamed `difference of-sums` to `difference-of-squares`.