### PR TITLE
Json pretty

### DIFF
--- a/code/config.ss
+++ b/code/config.ss
@@ -1,12 +1,12 @@
 (define track-config
   `((language . "Scheme")
-    
+
     (active . #t)
 
     (blurb . "")
 
     (exercises
-     
+
      ((slug . hello-world)
       (uuid . "f2936612-edc4-44f9-a403-c60f7c6486e4")
       (core . #f)
@@ -16,105 +16,105 @@
       (unlocked-by)
       (difficulty . 1)
       (topics))
-     
+
      ((slug . hamming)
       (uuid . "ce513303-471b-459a-bcf1-6c69f4d83ae7")
       (core . #f)
       (unlocked-by)
       (difficulty . 1)
       (topics list))
-     
+
      ((slug . leap)
       (uuid . "b94548df-3b35-4ce1-80c7-36179d2b3b86")
       (core . #f)
       (unlocked-by)
       (difficulty . 1)
       (topics))
-     
+
      ((slug . grains)
       (uuid . "397d9cfc-43f9-4c57-bc55-5c94ae8f532e")
       (core . #f)
       (unlocked-by)
       (difficulty . 1)
       (topics math))
-     
+
      ((slug . bob)
       (uuid . "4cf6697c-ad9e-426c-a2d8-6c3695812421")
       (core . #f)
       (unlocked-by)
       (difficulty . 1)
       (topics string))
-     
+
      ((slug . raindrops)
       (uuid . "9f13b913-a650-4cbf-a392-4b5614e1aa2a")
       (core . #f)
       (unlocked-by)
       (difficulty . 1)
       (topics))
-     
+
      ((slug . rna-transcription)
       (uuid . "26bf9c24-ba92-473e-9270-8964f1bf71f2")
       (core . #f)
       (unlocked-by)
       (difficulty . 1)
       (topics string))
-     
+
      ((slug . robot-name)
       (uuid . "62a5a71c-a9eb-416b-809c-c862a4828e8b")
       (core . #f)
       (unlocked-by)
       (difficulty . 1)
       (topics))
-     
+
      ((slug . phone-number)
       (uuid . "8ed74044-2361-459e-aca5-abd73ed5c1cb")
       (core . #f)
       (unlocked-by)
       (difficulty . 1)
       (topics string))
-     
+
      ((slug . anagram)
       (uuid . "c550055c-4bd5-478b-8e91-94347a314aef")
       (core . #f)
       (unlocked-by)
       (difficulty . 1)
       (topics string))
-     
+
      ((slug . nucleotide-count)
       (uuid . "d72cf2c3-9f30-4df1-a69b-04c638bb2426")
       (core . #f)
       (unlocked-by)
       (difficulty . 1)
       (topics))
-     
+
      ((slug . difference-of-squares)
       (uuid . "a3c7a4d2-ba08-47c9-a88e-2311ad02d945")
       (core . #f)
       (unlocked-by)
       (difficulty . 1)
       (topics math))
-     
+
      ((slug . list-ops)
       (uuid . "903374d2-8155-4fe3-bf90-5b6359c7b5cc")
       (core . #f)
       (unlocked-by)
       (difficulty . 1)
       (topics))
-     
+
      ((slug . scrabble-score)
       (uuid . "5b44ccd4-b1f4-4b86-89c8-f1dec5905ccb")
       (core . #f)
       (unlocked-by)
       (difficulty . 1)
       (topics))
-     
+
      ((slug . word-count)
       (uuid . "9460b65d-dc80-4a95-8782-b395d2cc979e")
       (core . #f)
       (unlocked-by)
       (difficulty . 1)
       (topics))
-     
+
      ((slug . two-fer)
       (uuid . "3ecc2d1c-55e0-45c9-ba35-57d7d8cfd51e")
       (core . #f)
@@ -130,7 +130,7 @@
       (difficulty . 2)
       (topics math vector)
       (wip))
-     
+
      ((slug . change)
       (uuid . "6f2d8731-2c2c-4faa-a9bf-11f785c2e5bc")
       (core . #f)
@@ -138,7 +138,7 @@
       (difficulty . 5)
       (topics dynamic-programming graph recursion)
       (wip))
-     
+
      ;; list problems
      ((slug . pascals-triangle)
       (uuid . "d5caff8b-ffaa-4055-9bb9-7d31a4480956")
@@ -147,8 +147,8 @@
       (difficulty . 4)
       (topics recursion list math)
       (wip))
-     
-;;     sublist wants order to matter. lame     
+
+;;     sublist wants order to matter. lame
      ((slug . "sublist")
       (uuid . "37e2745f-1437-4362-9230-aaf17a2a2170")
       (core . #f)
@@ -171,5 +171,5 @@
       (difficulty . 6)
       (topics optimization dynamic-programming search)
       (wip)))
-    
+
     ))

--- a/code/config.ss
+++ b/code/config.ss
@@ -12,7 +12,7 @@
       (core . #f)
       ;; nb configlet fmt rejects auto-approve but doesn't mind
       ;; unlocked-by.
-      (auto_approve . #t)
+      (auto-approve . #t)
       (unlocked-by)
       (difficulty . 1)
       (topics))
@@ -50,7 +50,7 @@
       (core . #f)
       (unlocked-by)
       (difficulty . 1)
-      (topics))
+      (topics conditionals association-lists))
 
      ((slug . rna-transcription)
       (uuid . "26bf9c24-ba92-473e-9270-8964f1bf71f2")

--- a/code/config.ss
+++ b/code/config.ss
@@ -50,7 +50,7 @@
       (core . #f)
       (unlocked-by)
       (difficulty . 1)
-      (topics conditionals association-lists))
+      (topics))
 
      ((slug . rna-transcription)
       (uuid . "26bf9c24-ba92-473e-9270-8964f1bf71f2")

--- a/code/json.sls
+++ b/code/json.sls
@@ -43,12 +43,6 @@
    (only (chezscheme) include)
    (packrat))
 
-  ;; Helper to convert from kebab-case to snake_case
-  (define (string-replace str old new)
-    (let ((old->new (lambda (c)
-                      (if (char=? c old) new c))))
-      (apply string (map old->new (string->list str)))))
-
   ;; Provide the message 'pretty to get pretty printed output
   ;; Otherwise pass any other symbol as the first argument
   ;; and you will get regular json without formatting
@@ -83,10 +77,8 @@
             (when pretty? (display-level p))
             (display "\"" p)
             (cond
-             ((symbol? k)
-              (display (string-replace (symbol->string k) #\- #\_) p))
-             ((string? k)
-              (display k p))
+             ((symbol? k) (display (symbol->string k) p))
+             ((string? k) (display k p))
              (else (error "Invalid JSON table key in json-write" k)))
             (display "\": " p)
             (write-any v p)))
@@ -123,9 +115,7 @@
               (number? x)) (write x p))
          ((boolean? x) (display (if x "true" "false") p))
          ((symbol? x)
-          (write (if (eq? x 'null)
-                     'null
-                     (string-replace (symbol->string x) #\- #\_))
+          (write (if (eq? x 'null) 'null (symbol->string x))
                  p)) ;; for convenience
          ((null? x) (display "null" p))
          ((and (list? x)

--- a/code/json.sls
+++ b/code/json.sls
@@ -43,10 +43,11 @@
    (only (chezscheme) include)
    (packrat))
 
+  ;; Helper to convert from kebab-case to snake_case
   (define (string-replace str old new)
-    (let ((old=? (lambda (c)
-                   (if (char=? c old) new c))))
-      (apply string (map old=? (string->list str)))))
+    (let ((old->new (lambda (c)
+                      (if (char=? c old) new c))))
+      (apply string (map old->new (string->list str)))))
 
   ;; Provide the message 'pretty to get pretty printed output
   ;; Otherwise pass any other symbol as the first argument
@@ -82,8 +83,10 @@
             (when pretty? (display-level p))
             (display "\"" p)
             (cond
-             ((symbol? k) (display (symbol->string k) p))
-             ((string? k) (display k p))
+             ((symbol? k)
+              (display (string-replace (symbol->string k) #\- #\_) p))
+             ((string? k)
+              (display k p))
              (else (error "Invalid JSON table key in json-write" k)))
             (display "\": " p)
             (write-any v p)))
@@ -119,8 +122,11 @@
          ((or (string? x)
               (number? x)) (write x p))
          ((boolean? x) (display (if x "true" "false") p))
-         ((symbol? x) (write (if (eq? x 'null) 'null (symbol->string x))
-                             p)) ;; for convenience
+         ((symbol? x)
+          (write (if (eq? x 'null)
+                     'null
+                     (string-replace (symbol->string x) #\- #\_))
+                 p)) ;; for convenience
          ((null? x) (display "null" p))
          ((and (list? x)
                (pair? (car x))

--- a/code/json.sls
+++ b/code/json.sls
@@ -43,6 +43,11 @@
    (only (chezscheme) include)
    (packrat))
 
+  (define (string-replace str old new)
+    (let ((old=? (lambda (c)
+                   (if (char=? c old) new c))))
+      (apply string (map old=? (string->list str)))))
+
   ;; Provide the message 'pretty to get pretty printed output
   ;; Otherwise pass any other symbol as the first argument
   ;; and you will get regular json without formatting

--- a/code/json.sls
+++ b/code/json.sls
@@ -43,9 +43,15 @@
    (only (chezscheme) include)
    (packrat))
 
-  ;; Provide the message 'pretty to get pretty printed output
-  ;; Otherwise pass any other symbol as the first argument
-  ;; and you will get regular json without formatting
+  ;; write-json :: sexp -> json
+  ;; The interface is three-fold and implemented as a case-lambda
+  ;; 1 argument  = simple unformatted json
+  ;; 2 arguments = first must be 'pretty
+  ;;                 any other symbol will throw an error
+  ;;               second must be the symbolic representation of a scheme object
+  ;; 3 arguments = first must be 'pretty
+  ;;               second must be the symbolic representation of a scheme object
+  ;;               third must be the tabpstop size defined in spaces
   (define json-write
     (let ()
       ;; control whether or not to pretty print
@@ -54,6 +60,7 @@
       (define indent-level 0)
       (define tabstop-size 2)
 
+      ;; Print the indentation level
       (define (display-level p)
         (display (make-string (* indent-level tabstop-size) #\space) p))
 

--- a/code/json.sls
+++ b/code/json.sls
@@ -3,7 +3,7 @@
 ;;
 ;; Copyright (c) 2005 Tony Garnock-Jones <tonyg@kcbbs.gen.nz>
 ;; Copyright (c) 2005 LShift Ltd. <query@lshift.net>
-;; 
+;;
 ;; Permission is hereby granted, free of charge, to any person
 ;; obtaining a copy of this software and associated documentation
 ;; files (the "Software"), to deal in the Software without
@@ -11,10 +11,10 @@
 ;; modify, merge, publish, distribute, sublicense, and/or sell copies
 ;; of the Software, and to permit persons to whom the Software is
 ;; furnished to do so, subject to the following conditions:
-;; 
+;;
 ;; The above copyright notice and this permission notice shall be
 ;; included in all copies or substantial portions of the Software.
-;; 
+;;
 ;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 ;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 ;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -30,172 +30,207 @@
 
 (library (json)
   (export json-write
-	  json-read)
-  
-  (import
-    (except (rnrs) define-record-type error)
-    (rnrs r5rs)
-    (rnrs mutable-pairs)
-    (only (srfi :1 lists) lset-union append-map fold)
-    (srfi :6 basic-string-ports)
-    (srfi :9 records)
-    (srfi :23 error)
-    (only (chezscheme) include)
-    (packrat))
+          json-read)
 
+  (import
+   (except (rnrs) define-record-type error)
+   (rnrs r5rs)
+   (rnrs mutable-pairs)
+   (only (srfi :1 lists) lset-union append-map fold)
+   (srfi :6 basic-string-ports)
+   (srfi :9 records)
+   (srfi :23 error)
+   (only (chezscheme) include)
+   (packrat))
+
+  ;; Provide the message 'pretty to get pretty printed output
+  ;; Otherwise pass any other symbol as the first argument
+  ;; and you will get regular json without formatting
   (define json-write
     (let ()
+      ;; control whether or not to pretty print
+      (define pretty? #f)
+      ;; control variables for pretty printing
+      (define indent-level 0)
+      (define tabstop-size 2)
+
+      (define (display-level p)
+        (display (make-string (* indent-level tabstop-size) #\space) p))
+
       (define (write-ht vec p)
-	(display "{" p)
-	(do ((need-comma #f #t)
-	     (vec vec (cdr vec)))
-	    ((null? vec))
-	  (if need-comma
-	      (display ", " p)
-	      (set! need-comma #t))
-	  (let* ((entry (car vec))
-		 (k (car entry))
-		 (v (cdr entry)))
-	    (cond
-	      ((symbol? k) (write (symbol->string k) p))
-	      ((string? k) (write k p)) ;; for convenience
-	      (else (error "Invalid JSON table key in json-write" k)))
-	    (display ": " p)
-	    (write-any v p)))
-	(display "}" p))
+        (display "{" p)
+        (when pretty?
+          (display "\n" p)
+          (set! indent-level (+ indent-level 1)))
+        (do ((need-comma #f #t)
+             (vec vec (cdr vec)))
+            ((null? vec))
+          (if need-comma
+              (begin (display "," p)
+                     (if pretty?
+                         (display "\n" p)
+                         (display " " p)))
+              (set! need-comma #t))
+          (let* ((entry (car vec))
+                 (k (car entry))
+                 (v (cdr entry)))
+            (when pretty? (display-level p))
+            (display "\"" p)
+            (cond
+             ((symbol? k) (display (symbol->string k) p))
+             ((string? k) (display k p))
+             (else (error "Invalid JSON table key in json-write" k)))
+            (display "\": " p)
+            (write-any v p)))
+        (when pretty?
+          (set! indent-level (- indent-level 1))
+          (display "\n")
+          (display-level p))
+        (display "}" p))
 
       (define (write-array a p)
-	(display "[" p)
-	(let ((need-comma #f))
-	  (for-each (lambda (v)
-		      (if need-comma
-			  (display ", " p)
-			  (set! need-comma #t))
-		      (write-any v p))
-		    a))
-	(display "]" p))
+        (display "[" p)
+        (when pretty?
+          (display "\n" p)
+          (set! indent-level (+ indent-level 1)))
+        (let ((need-comma #f))
+          (for-each (lambda (v)
+                      (if need-comma
+                          (if pretty?
+                              (display ",\n" p)
+                              (display "," p))
+                          (set! need-comma #t))
+                      (when pretty? (display-level p))
+                      (write-any v p))
+                    a))
+        (when pretty?
+          (set! indent-level (- indent-level 1))
+          (display "\n")
+          (display-level p))
+        (display "]" p))
 
       (define (write-any x p)
-	(cond
-	  ((or (string? x)
-	       (number? x)) (write x p))
-	  ((boolean? x) (display (if x "true" "false") p))
-	  ((symbol? x) (write (if (eq? x 'null) 'null (symbol->string x))
-			      p)) ;; for convenience
-	  ((null? x) (display "null" p))
-	  ((and (list? x)
-		(pair? (car x))
-		(not (pair? (caar x))))
-	   (write-ht x p))
-	  ((list? x) (write-array x p))
-	  (else (error "Invalid JSON object in json-write" x))))
+        (cond
+         ((or (string? x)
+              (number? x)) (write x p))
+         ((boolean? x) (display (if x "true" "false") p))
+         ((symbol? x) (write (if (eq? x 'null) 'null (symbol->string x))
+                             p)) ;; for convenience
+         ((null? x) (display "null" p))
+         ((and (list? x)
+               (pair? (car x))
+               (not (pair? (caar x))))
+          (write-ht x p))
+         ((list? x) (write-array x p))
+         (else (error "Invalid JSON object in json-write" x))))
 
-      (lambda (x . maybe-port)
-	(write-any x (if (pair? maybe-port) (car maybe-port) (current-output-port))))))
+      (lambda (msg x . maybe-port)
+        (case msg ((pretty) (set! pretty? #t)))
+        (write-any x (if (pair? maybe-port) (car maybe-port) (current-output-port))))))
 
   (define json-read
     (let ()
       (define (generator p)
-	(let ((ateof #f)
-	      (pos (top-parse-position "<?>")))
-	  (lambda ()
-	    (if ateof
-		(values pos #f)
-		(let ((x (read-char p)))
-		  (if (eof-object? x)
-		      (begin
-			(set! ateof #t)
-			(values pos #f))
-		      (let ((old-pos pos))
-			(set! pos (update-parse-position pos x))
-			(values old-pos (cons x x)))))))))
+        (let ((ateof #f)
+              (pos (top-parse-position "<?>")))
+          (lambda ()
+            (if ateof
+                (values pos #f)
+                (let ((x (read-char p)))
+                  (if (eof-object? x)
+                      (begin
+                        (set! ateof #t)
+                        (values pos #f))
+                      (let ((old-pos pos))
+                        (set! pos (update-parse-position pos x))
+                        (values old-pos (cons x x)))))))))
 
       (define parser
-	(packrat-parser (begin
-			  (define (white results)
-			    (if (char-whitespace? (parse-results-token-value results))
-				(white (parse-results-next results))
-				(comment results)))
-			  (define (skip-comment-char results)
-			    (comment-body (parse-results-next results)))
-			  (define (skip-to-newline results)
-			    (if (memv (parse-results-token-value results) '(#\newline #\return))
-				(white results)
-				(skip-to-newline (parse-results-next results))))
-			  (define (token str)
-			    (lambda (starting-results)
-			      (let loop ((pos 0) (results starting-results))
-				(if (= pos (string-length str))
-				    (make-result str results)
-				    (if (char=? (parse-results-token-value results) (string-ref str pos))
-					(loop (+ pos 1) (parse-results-next results))
-					(make-expected-result (parse-results-position starting-results) str))))))
-			  (define (interpret-string-escape results k)
-			    (let ((ch (parse-results-token-value results)))
-			      (k (cond
-				   ((assv ch '((#\b . #\backspace)
-					       (#\n . #\newline)
-					       (#\f . #\page)
-					       (#\r . #\return)
-					       (#\t . #\tab))) => cdr) ;; we don't support the "u" escape for unicode
-				   (else ch))
-				 (parse-results-next results))))
-			  (define (jstring-body results)
-			    (let loop ((acc '()) (results results))
-			      (let ((ch (parse-results-token-value results)))
-				(case ch
-				  ((#\\) (interpret-string-escape (parse-results-next results)
-								  (lambda (val results)
-								    (loop (cons val acc) results))))
-				  ((#\") (make-result (list->string (reverse acc)) results))
-				  (else (loop (cons ch acc) (parse-results-next results)))))))
-			  (define (jnumber-body starting-results)
-			    (let loop ((acc '()) (results starting-results))
-			      (let ((ch (parse-results-token-value results)))
-				(if (memv ch '(#\- #\+ #\0 #\1 #\2 #\3 #\4 #\5 #\6 #\7 #\8 #\9 #\. #\e #\E))
-				    (loop (cons ch acc) (parse-results-next results))
-				    (let ((n (string->number (list->string (reverse acc)))))
-				      (if n
-					  (make-result n results)
-					  (make-expected-result (parse-results-position starting-results) 'number)))))))
-			  any)
-			(any ((white '#\{ entries <- table-entries white '#\}) entries)
-			     ((white '#\[ entries <- array-entries white '#\]) entries)
-			     ((s <- jstring) s)
-			     ((n <- jnumber) n)
-			     ((white (token "true")) #t)
-			     ((white (token "false")) #f)
-			     ((white (token "null")) '()))
-			(comment (((token "/*") b <- comment-body) b)
-				 (((token "//") b <- skip-to-newline) b)
-				 (() 'whitespace))
-			(comment-body (((token "*/") w <- white) w)
-				      ((skip-comment-char) 'skipped-comment-char))
-			(table-entries ((a <- table-entries-nonempty) a)
-				       (() '()))
-			(table-entries-nonempty ((entry <- table-entry white '#\, entries <- table-entries-nonempty) (cons entry entries))
-						((entry <- table-entry) (list entry)))
-			(table-entry ((key <- jstring white '#\: val <- any) (cons (string->symbol key) val)))
-			(array-entries ((a <- array-entries-nonempty) a)
-				       (() '()))
-			(array-entries-nonempty ((entry <- any white '#\, entries <- array-entries-nonempty) (cons entry entries))
-						((entry <- any) (list entry)))
-			(jstring ((white '#\" body <- jstring-body '#\") body))
-			(jnumber ((white body <- jnumber-body) body))
-			))
+        (packrat-parser (begin
+                          (define (white results)
+                            (if (char-whitespace? (parse-results-token-value results))
+                                (white (parse-results-next results))
+                                (comment results)))
+                          (define (skip-comment-char results)
+                            (comment-body (parse-results-next results)))
+                          (define (skip-to-newline results)
+                            (if (memv (parse-results-token-value results) '(#\newline #\return))
+                                (white results)
+                                (skip-to-newline (parse-results-next results))))
+                          (define (token str)
+                            (lambda (starting-results)
+                              (let loop ((pos 0) (results starting-results))
+                                (if (= pos (string-length str))
+                                    (make-result str results)
+                                    (if (char=? (parse-results-token-value results) (string-ref str pos))
+                                        (loop (+ pos 1) (parse-results-next results))
+                                        (make-expected-result (parse-results-position starting-results) str))))))
+                          (define (interpret-string-escape results k)
+                            (let ((ch (parse-results-token-value results)))
+                              (k (cond
+                                  ((assv ch '((#\b . #\backspace)
+                                              (#\n . #\newline)
+                                              (#\f . #\page)
+                                              (#\r . #\return)
+                                              (#\t . #\tab))) => cdr) ;; we don't support the "u" escape for unicode
+                                  (else ch))
+                                 (parse-results-next results))))
+                          (define (jstring-body results)
+                            (let loop ((acc '()) (results results))
+                              (let ((ch (parse-results-token-value results)))
+                                (case ch
+                                  ((#\\) (interpret-string-escape (parse-results-next results)
+                                                                  (lambda (val results)
+                                                                    (loop (cons val acc) results))))
+                                  ((#\") (make-result (list->string (reverse acc)) results))
+                                  (else (loop (cons ch acc) (parse-results-next results)))))))
+                          (define (jnumber-body starting-results)
+                            (let loop ((acc '()) (results starting-results))
+                              (let ((ch (parse-results-token-value results)))
+                                (if (memv ch '(#\- #\+ #\0 #\1 #\2 #\3 #\4 #\5 #\6 #\7 #\8 #\9 #\. #\e #\E))
+                                    (loop (cons ch acc) (parse-results-next results))
+                                    (let ((n (string->number (list->string (reverse acc)))))
+                                      (if n
+                                          (make-result n results)
+                                          (make-expected-result (parse-results-position starting-results) 'number)))))))
+                          any)
+                        (any ((white '#\{ entries <- table-entries white '#\}) entries)
+                             ((white '#\[ entries <- array-entries white '#\]) entries)
+                             ((s <- jstring) s)
+                             ((n <- jnumber) n)
+                             ((white (token "true")) #t)
+                             ((white (token "false")) #f)
+                             ((white (token "null")) '()))
+                        (comment (((token "/*") b <- comment-body) b)
+                                 (((token "//") b <- skip-to-newline) b)
+                                 (() 'whitespace))
+                        (comment-body (((token "*/") w <- white) w)
+                                      ((skip-comment-char) 'skipped-comment-char))
+                        (table-entries ((a <- table-entries-nonempty) a)
+                                       (() '()))
+                        (table-entries-nonempty ((entry <- table-entry white '#\, entries <- table-entries-nonempty) (cons entry entries))
+                                                ((entry <- table-entry) (list entry)))
+                        (table-entry ((key <- jstring white '#\: val <- any) (cons (string->symbol key) val)))
+                        (array-entries ((a <- array-entries-nonempty) a)
+                                       (() '()))
+                        (array-entries-nonempty ((entry <- any white '#\, entries <- array-entries-nonempty) (cons entry entries))
+                                                ((entry <- any) (list entry)))
+                        (jstring ((white '#\" body <- jstring-body '#\") body))
+                        (jnumber ((white body <- jnumber-body) body))
+                        ))
 
       (define (read-any p)
-	(let ((result (parser (base-generator->results (generator p)))))
-	  (if (parse-result-successful? result)
-	      (parse-result-semantic-value result)
-	      (error "JSON Parse Error"
-		     (let ((e (parse-result-error result)))
-		       (list 'json-parse-error
-			     (parse-position->string (parse-error-position e))
-			     (parse-error-expected e)
-			     (parse-error-messages e)))))))
+        (let ((result (parser (base-generator->results (generator p)))))
+          (if (parse-result-successful? result)
+              (parse-result-semantic-value result)
+              (error "JSON Parse Error"
+                     (let ((e (parse-result-error result)))
+                       (list 'json-parse-error
+                             (parse-position->string (parse-error-position e))
+                             (parse-error-expected e)
+                             (parse-error-messages e)))))))
 
       (lambda maybe-port
-	(read-any (if (pair? maybe-port) (car maybe-port) (current-input-port))))))
+        (read-any (if (pair? maybe-port) (car maybe-port) (current-input-port))))))
 
   )

--- a/code/outils.ss
+++ b/code/outils.ss
@@ -1,8 +1,9 @@
 ;; helpful procedures
 
+;; Convenience for grabbing alist values by key
 (define (lookup key alist)
   (cond ((assoc key alist) => cdr)
-	(else (error 'lookup "key not in alist" key alist))))
+        (else (error 'lookup "key not in alist" key alist))))
 
 (define (lookup-partial key)
   (lambda (alist)
@@ -10,15 +11,15 @@
 
 (define (lookup-spine keys alist)
   (fold-left (lambda (alist key)
-	       (lookup key alist))
-	     alist
-	     keys))
+               (lookup key alist))
+             alist
+             keys))
 
 (define (read-all)
   (let loop ((sexp (read)) (config '()))
     (if (eof-object? sexp)
-	(reverse config)
-	(loop (read) (cons sexp config)))))
+        (reverse config)
+        (loop (read) (cons sexp config)))))
 
 (define (write-expression-to-file code file)
   (when (file-exists? file)
@@ -26,8 +27,8 @@
   (with-output-to-file file
     (lambda ()
       (for-each (lambda (line)
-		  (pretty-print line) (newline))
-		code))))
+                  (pretty-print line) (newline))
+                code))))
 
 (define (update-config)
   (load "code/config.ss"))

--- a/code/track.ss
+++ b/code/track.ss
@@ -7,6 +7,25 @@
       (lambda ()
         (json-write 'pretty (process-config))))))
 
+;; Top level helper for make-config
+(define (process-config)
+  (map (lambda (x)
+         (if (not (eq? (car x) 'exercises))
+             x
+             (cons 'exercises
+                   (exercises->snake-case
+                    (remp (lambda (exercise)
+                            (memq 'wip (map car exercise)))
+                          (cdr x))))))
+       track-config))
+
+;; Top level helper for process config
+(define (exercises->snake-case exercises)
+  (let ((handle (lambda (exercise)
+                  (map format-js-pair exercise))))
+    (map handle exercises)))
+
+;; Helpers for exercises->snake-case
 (define (kebab->snake str)
   (let ((k->s (lambda (c) (if (char=? c #\-) #\_ c))))
     (apply string (map k->s (string->list str)))))
@@ -18,26 +37,13 @@
   (let ((snake-key (sym-bol->str_ing (car pair))))
     (if (null? (cdr pair))
         `(,snake-key)
+        ;; sort the topics list
         (if (symbol=? 'topics (car pair))
             (cons snake-key (sort string<?
                                   (map sym-bol->str_ing (cdr pair))))
+            ;; regular pair for everything else
             `(,snake-key . ,(cdr pair))))))
-
-(define (exercises->snake-case exercises)
-  (let ((handle
-         (lambda (exercise)
-           (map format-js-pair exercise))))
-    (map handle exercises)))
-
-(define (process-config)
-  (map (lambda (x)
-         (if (not (eq? (car x) 'exercises))
-             x
-             `(exercises . ,(exercises->snake-case
-                             (remp (lambda (exercise)
-                                     (memq 'wip (map car exercise)))
-                                   (cdr x))))))
-       track-config))
+;; End helpers for make-config
 
 (define (configlet-uuid)
   (let ((from-to-pid (process "./bin/configlet uuid")))

--- a/code/track.ss
+++ b/code/track.ss
@@ -5,7 +5,7 @@
       (delete-file config.json))
     (with-output-to-file config.json
       (lambda ()
-	(json-write (process-config))))))
+	(json-write 'pretty (process-config))))))
 
 (define (process-config)
   (map (lambda (x)

--- a/code/track.ss
+++ b/code/track.ss
@@ -5,15 +5,38 @@
       (delete-file config.json))
     (with-output-to-file config.json
       (lambda ()
-	(json-write 'pretty (process-config))))))
+        (json-write 'pretty (process-config))))))
+
+(define (kebab->snake str)
+  (let ((k->s (lambda (c) (if (char=? c #\-) #\_ c))))
+    (apply string (map k->s (string->list str)))))
+
+(define (exercises->snake-case exercises)
+  (let* ((sym-bol->str_ing
+          (lambda (s) (kebab->snake (symbol->string s))))
+         (format-pair
+          (lambda (pair)
+            (let ((snake-key (sym-bol->str_ing (car pair))))
+              (if (null? (cdr pair))
+                  `(,snake-key)
+                  (if (symbol=? 'topics (car pair))
+                      (cons snake-key
+                            (sort string<?
+                                  (map sym-bol->str_ing (cdr pair))))
+                      `(,snake-key . ,(cdr pair)))))))
+         (handle
+          (lambda (exercise)
+            (map format-pair exercise))))
+    (map handle exercises)))
 
 (define (process-config)
   (map (lambda (x)
          (if (not (eq? (car x) 'exercises))
              x
-             `(exercises . ,(remp (lambda (exercise)
-                                    (memq 'wip (map car exercise)))
-                                  (cdr x)))))
+             `(exercises . ,(exercises->snake-case
+                             (remp (lambda (exercise)
+                                     (memq 'wip (map car exercise)))
+                                   (cdr x))))))
        track-config))
 
 (define (configlet-uuid)
@@ -27,27 +50,27 @@
 ;; as this one. Makefile helps ensure this.
 (define (get-problem-specification problem)
   (let* ((problem-dir (format "../problem-specifications/exercises/~a" problem))
-	 (spec (directory-list problem-dir)))
+         (spec (directory-list problem-dir)))
     (map (lambda (file)
-	   (format "~a/~a" problem-dir file))
-	 spec)))
+           (format "~a/~a" problem-dir file))
+         spec)))
 
 (define (write-problem-description problem)
   (let ((file (find (lambda (spec)
-		      (string=? "md" (path-extension spec)))
-		    (get-problem-specification problem)))
-	(dir (format "code/exercises/~a" problem)))
+                      (string=? "md" (path-extension spec)))
+                    (get-problem-specification problem)))
+        (dir (format "code/exercises/~a" problem)))
     (unless file
       (error 'get-problem-description "couldn't find description" problem))
     (system (format "mkdir -p ~a && cp ~a ~a/README.md"
-		    dir file dir))))
+                    dir file dir))))
 
 ;; assumes only file in problem directory that is json is the test
 ;; case suite.
 (define (get-test-specification problem)
   (let ((test-suite-file (find (lambda (spec)
-				 (string=? "json" (path-extension spec)))
-			       (get-problem-specification problem))))
+                                 (string=? "json" (path-extension spec)))
+                               (get-problem-specification problem))))
     (unless test-suite-file
       (error 'get-test-specification "couldn't find test suite for" problem))
     (with-input-from-file test-suite-file json-read)))
@@ -64,10 +87,10 @@
 
 (define (put-problem! problem implementation)
   (for-each (lambda (aspect)
-	      (unless (assoc aspect implementation)
-		(error 'put-test! "problem does not implement" problem aspect)))
-	    ;; test is an sexpression. skeleton and solution are file paths
-	    '(test skeleton solution))
+              (unless (assoc aspect implementation)
+                (error 'put-test! "problem does not implement" problem aspect)))
+            ;; test is an sexpression. skeleton and solution are file paths
+            '(test skeleton solution))
   (hashtable-set! *problem-table* problem implementation))
 
 (define (get-problem problem)
@@ -79,47 +102,47 @@
 (define (write-exercise problem)
   (let ((implementation (get-problem problem)))
     (let* ((dir (format "_build/exercises/~a" problem))
-	   (src (format "code/exercises/~a" problem))
-	   (test.scm (format "~a/test.scm" dir))
-	   (skeleton.scm (format "~a/~a" src (lookup 'skeleton implementation)))
-	   (solution.scm (format "~a/~a" src (lookup 'solution implementation)))
-	   (README.md (format "~a/README.md" src)))
+           (src (format "code/exercises/~a" problem))
+           (test.scm (format "~a/test.scm" dir))
+           (skeleton.scm (format "~a/~a" src (lookup 'skeleton implementation)))
+           (solution.scm (format "~a/~a" src (lookup 'solution implementation)))
+           (README.md (format "~a/README.md" src)))
       (format #t "writing _build/~a~%" problem)
       (system
-	(format "mkdir -p ~a && cp ~a ~a && cp ~a ~a && cp ~a ~a"
-		dir skeleton.scm dir solution.scm dir README.md dir))
+       (format "mkdir -p ~a && cp ~a ~a && cp ~a ~a && cp ~a ~a"
+               dir skeleton.scm dir solution.scm dir README.md dir))
       (write-expression-to-file (lookup 'test implementation) test.scm))))
 
 (define (setup-exercism problem)
   (format #t "setting up ~a~%" problem)
   (let* ((dir (format "code/exercises/~a" problem))
-	 (implementation (format "~a/~a.ss" dir problem))
+         (implementation (format "~a/~a.ss" dir problem))
          ;; todo, add "properties" found in spec to stub skeleton and solution
-	 (skeleton (format "~a/~a.scm" dir problem))
-	 (solution (format "~a/example.scm" dir))
+         (skeleton (format "~a/~a.scm" dir problem))
+         (solution (format "~a/example.scm" dir))
          ;; see code/exercises/anagram/anagram.ss for more information
-	 (stub-implementation
-	  `(,@'((define (parse-test test)
-		  `(lambda ()
-		     (test-success (lookup 'description test)
-				   equal?
-				   problem
-				   (lookup 'input test)
-				   (lookup 'expected test))))
-		(define (spec->tests spec)
-		  `(,@*test-definitions*
+         (stub-implementation
+          `(,@'((define (parse-test test)
+                  `(lambda ()
+                     (test-success (lookup 'description test)
+                                   equal?
+                                   problem
+                                   (lookup 'input test)
+                                   (lookup 'expected test))))
+                (define (spec->tests spec)
+                  `(,@*test-definitions*
                     (define (test . args)
-                       (apply run-test-suite
-                              (list ,@(map parse-test (lookup 'cases spec)))
-                              args)))))
-	    (put-problem! ',problem
-			  ;; fixme, quoted expression for test not working 
-			  `((test . ,(spec->tests
-				      (get-test-specification ',problem)))
-			    (skeleton . ,,(path-last skeleton))
-			    (solution . ,,(path-last solution))))))
-	 (stub-solution `((define (,problem)
-			    'implement-me!))))
+                      (apply run-test-suite
+                             (list ,@(map parse-test (lookup 'cases spec)))
+                             args)))))
+            (put-problem! ',problem
+                          ;; fixme, quoted expression for test not working
+                          `((test . ,(spec->tests
+                                      (get-test-specification ',problem)))
+                            (skeleton . ,,(path-last skeleton))
+                            (solution . ,,(path-last solution))))))
+         (stub-solution `((define (,problem)
+                            'implement-me!))))
     (when (file-exists? implementation)
       (error 'setup-exercism "implementation already exists" problem))
     (format #t "~~ getting description~%")
@@ -161,7 +184,7 @@
             (error 'verify-output "bad implementation!" problem)))))
     (format #t "updating exercises/~a~%" problem)
     ;; for now hold off on using new problems 
-;;    (system (format "rm -rf exercises/~a && cp -r ~a exercises/~a" problem dir problem))
+    ;;    (system (format "rm -rf exercises/~a && cp -r ~a exercises/~a" problem dir problem))
     'done))
 
 (define (build-implementations)

--- a/code/track.ss
+++ b/code/track.ss
@@ -7,44 +7,6 @@
       (lambda ()
         (json-write 'pretty (process-config))))))
 
-;; Top level helper for make-config
-(define (process-config)
-  (map (lambda (x)
-         (if (not (eq? (car x) 'exercises))
-             x
-             (cons 'exercises
-                   (exercises->snake-case
-                    (remp (lambda (exercise)
-                            (memq 'wip (map car exercise)))
-                          (cdr x))))))
-       track-config))
-
-;; Top level helper for process config
-(define (exercises->snake-case exercises)
-  (let ((handle (lambda (exercise)
-                  (map format-js-pair exercise))))
-    (map handle exercises)))
-
-;; Helpers for exercises->snake-case
-(define (kebab->snake str)
-  (let ((k->s (lambda (c) (if (char=? c #\-) #\_ c))))
-    (apply string (map k->s (string->list str)))))
-
-(define (sym-bol->str_ing symbol)
-  (kebab->snake (symbol->string symbol)))
-
-(define (format-js-pair pair)
-  (let ((snake-key (sym-bol->str_ing (car pair))))
-    (if (null? (cdr pair))
-        `(,snake-key)
-        ;; sort the topics list
-        (if (symbol=? 'topics (car pair))
-            (cons snake-key (sort string<?
-                                  (map sym-bol->str_ing (cdr pair))))
-            ;; regular pair for everything else
-            `(,snake-key . ,(cdr pair))))))
-;; End helpers for make-config
-
 (define (configlet-uuid)
   (let ((from-to-pid (process "./bin/configlet uuid")))
     (let ((fresh-uuid (read (car from-to-pid))))

--- a/code/track.ss
+++ b/code/track.ss
@@ -11,22 +11,22 @@
   (let ((k->s (lambda (c) (if (char=? c #\-) #\_ c))))
     (apply string (map k->s (string->list str)))))
 
-(define (exercises->snake-case exercises)
-  (let* ((sym-bol->str_ing
-          (lambda (s) (kebab->snake (symbol->string s))))
-         (format-pair
-          (lambda (pair)
-            (let ((snake-key (sym-bol->str_ing (car pair))))
-              (if (null? (cdr pair))
-                  `(,snake-key)
-                  (if (symbol=? 'topics (car pair))
-                      (cons snake-key
-                            (sort string<?
+(define (sym-bol->str_ing symbol)
+  (kebab->snake (symbol->string symbol)))
+
+(define (format-js-pair pair)
+  (let ((snake-key (sym-bol->str_ing (car pair))))
+    (if (null? (cdr pair))
+        `(,snake-key)
+        (if (symbol=? 'topics (car pair))
+            (cons snake-key (sort string<?
                                   (map sym-bol->str_ing (cdr pair))))
-                      `(,snake-key . ,(cdr pair)))))))
-         (handle
-          (lambda (exercise)
-            (map format-pair exercise))))
+            `(,snake-key . ,(cdr pair))))))
+
+(define (exercises->snake-case exercises)
+  (let ((handle
+         (lambda (exercise)
+           (map format-js-pair exercise))))
     (map handle exercises)))
 
 (define (process-config)

--- a/config.json
+++ b/config.json
@@ -57,8 +57,8 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "conditionals",
-        "association_lists"
+        "association_lists",
+        "conditionals"
       ]
     },
     {
@@ -156,8 +156,8 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "string",
-        "cipher"
+        "cipher",
+        "string"
       ]
     }
   ]

--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
   "blurb": "",
   "exercises": [
     {
-      "slug": "hello_world",
+      "slug": "hello-world",
       "uuid": "f2936612-edc4-44f9-a403-c60f7c6486e4",
       "core": false,
       "auto_approve": true,
@@ -62,7 +62,7 @@
       ]
     },
     {
-      "slug": "rna_transcription",
+      "slug": "rna-transcription",
       "uuid": "26bf9c24-ba92-473e-9270-8964f1bf71f2",
       "core": false,
       "unlocked_by": null,
@@ -72,7 +72,7 @@
       ]
     },
     {
-      "slug": "robot_name",
+      "slug": "robot-name",
       "uuid": "62a5a71c-a9eb-416b-809c-c862a4828e8b",
       "core": false,
       "unlocked_by": null,
@@ -80,7 +80,7 @@
       "topics": null
     },
     {
-      "slug": "phone_number",
+      "slug": "phone-number",
       "uuid": "8ed74044-2361-459e-aca5-abd73ed5c1cb",
       "core": false,
       "unlocked_by": null,
@@ -100,7 +100,7 @@
       ]
     },
     {
-      "slug": "nucleotide_count",
+      "slug": "nucleotide-count",
       "uuid": "d72cf2c3-9f30-4df1-a69b-04c638bb2426",
       "core": false,
       "unlocked_by": null,
@@ -108,7 +108,7 @@
       "topics": null
     },
     {
-      "slug": "difference_of_squares",
+      "slug": "difference-of-squares",
       "uuid": "a3c7a4d2-ba08-47c9-a88e-2311ad02d945",
       "core": false,
       "unlocked_by": null,
@@ -118,7 +118,7 @@
       ]
     },
     {
-      "slug": "list_ops",
+      "slug": "list-ops",
       "uuid": "903374d2-8155-4fe3-bf90-5b6359c7b5cc",
       "core": false,
       "unlocked_by": null,
@@ -126,7 +126,7 @@
       "topics": null
     },
     {
-      "slug": "scrabble_score",
+      "slug": "scrabble-score",
       "uuid": "5b44ccd4-b1f4-4b86-89c8-f1dec5905ccb",
       "core": false,
       "unlocked_by": null,
@@ -134,7 +134,7 @@
       "topics": null
     },
     {
-      "slug": "word_count",
+      "slug": "word-count",
       "uuid": "9460b65d-dc80-4a95-8782-b395d2cc979e",
       "core": false,
       "unlocked_by": null,
@@ -142,7 +142,7 @@
       "topics": null
     },
     {
-      "slug": "two_fer",
+      "slug": "two-fer",
       "uuid": "3ecc2d1c-55e0-45c9-ba35-57d7d8cfd51e",
       "core": false,
       "unlocked_by": null,
@@ -150,7 +150,7 @@
       "topics": null
     },
     {
-      "slug": "atbash_cipher",
+      "slug": "atbash-cipher",
       "uuid": "82169e85-3938-48da-ada9-7394adadc57a",
       "core": false,
       "unlocked_by": null,

--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
   "blurb": "",
   "exercises": [
     {
-      "slug": "hello-world",
+      "slug": "hello_world",
       "uuid": "f2936612-edc4-44f9-a403-c60f7c6486e4",
       "core": false,
       "auto_approve": true,
@@ -56,10 +56,13 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
-      "topics": null
+      "topics": [
+        "conditionals",
+        "association_lists"
+      ]
     },
     {
-      "slug": "rna-transcription",
+      "slug": "rna_transcription",
       "uuid": "26bf9c24-ba92-473e-9270-8964f1bf71f2",
       "core": false,
       "unlocked_by": null,
@@ -69,7 +72,7 @@
       ]
     },
     {
-      "slug": "robot-name",
+      "slug": "robot_name",
       "uuid": "62a5a71c-a9eb-416b-809c-c862a4828e8b",
       "core": false,
       "unlocked_by": null,
@@ -77,7 +80,7 @@
       "topics": null
     },
     {
-      "slug": "phone-number",
+      "slug": "phone_number",
       "uuid": "8ed74044-2361-459e-aca5-abd73ed5c1cb",
       "core": false,
       "unlocked_by": null,
@@ -97,7 +100,7 @@
       ]
     },
     {
-      "slug": "nucleotide-count",
+      "slug": "nucleotide_count",
       "uuid": "d72cf2c3-9f30-4df1-a69b-04c638bb2426",
       "core": false,
       "unlocked_by": null,
@@ -105,7 +108,7 @@
       "topics": null
     },
     {
-      "slug": "difference-of-squares",
+      "slug": "difference_of_squares",
       "uuid": "a3c7a4d2-ba08-47c9-a88e-2311ad02d945",
       "core": false,
       "unlocked_by": null,
@@ -115,7 +118,7 @@
       ]
     },
     {
-      "slug": "list-ops",
+      "slug": "list_ops",
       "uuid": "903374d2-8155-4fe3-bf90-5b6359c7b5cc",
       "core": false,
       "unlocked_by": null,
@@ -123,7 +126,7 @@
       "topics": null
     },
     {
-      "slug": "scrabble-score",
+      "slug": "scrabble_score",
       "uuid": "5b44ccd4-b1f4-4b86-89c8-f1dec5905ccb",
       "core": false,
       "unlocked_by": null,
@@ -131,7 +134,7 @@
       "topics": null
     },
     {
-      "slug": "word-count",
+      "slug": "word_count",
       "uuid": "9460b65d-dc80-4a95-8782-b395d2cc979e",
       "core": false,
       "unlocked_by": null,
@@ -139,7 +142,7 @@
       "topics": null
     },
     {
-      "slug": "two-fer",
+      "slug": "two_fer",
       "uuid": "3ecc2d1c-55e0-45c9-ba35-57d7d8cfd51e",
       "core": false,
       "unlocked_by": null,
@@ -147,14 +150,14 @@
       "topics": null
     },
     {
-      "slug": "atbash-cipher",
+      "slug": "atbash_cipher",
       "uuid": "82169e85-3938-48da-ada9-7394adadc57a",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "cipher",
-        "string"
+        "string",
+        "cipher"
       ]
     }
   ]

--- a/config.json
+++ b/config.json
@@ -56,10 +56,7 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
-      "topics": [
-        "association_lists",
-        "conditionals"
-      ]
+      "topics": null
     },
     {
       "slug": "rna-transcription",


### PR DESCRIPTION
This is a patch to handle pretty printing the json for the website config stuff from our in house scheme configs.

It now successfully converts `-` to `_` when going from scheme symbols to json strings.  Strings are left alone so as not to disturb the exercise `UUID`s.

