### PR TITLE
fix bug in test-error procedure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ $(readme-splice) : $(track-documentation)
 	cp docs/TESTS.md $@
 
 # exercises
-exercises/% : code/track.ss code/md.ss code/exercises/%/* code/stub-makefile code/docs/tests.ss
+exercises/% : code/*.ss code/exercises/%/* code/stub-makefile code/docs/tests.ss
 	$(call exercise, "(make-exercism '$(@F))")
 
 # build track

--- a/code/exercises/phone-number/example.scm
+++ b/code/exercises/phone-number/example.scm
@@ -23,7 +23,10 @@
 
 (define (clean phone-number)
   (let ((cleaned (split-phone-number phone-number)))
-    (when (char=? #\0 (string-ref cleaned 4))
+    (when (or (char=? #\0 (string-ref cleaned 3))
+	      (char=? #\1 (string-ref cleaned 3))
+	      (char=? #\0 (string-ref cleaned 0))
+	      (char=? #\1 (string-ref cleaned 0)))
       (error 'clean "exchange code begins with 0" phone-number))
     cleaned))
 

--- a/code/test.ss
+++ b/code/test.ss
@@ -25,16 +25,16 @@
 
 (define (test-error description procedure input)
   (call/cc
-    (lambda (k)
-      (with-exception-handler
-        (lambda (e)
-          (k `(pass . ,description)))
-	(lambda ()
-	  (test-run-scheme procedure input)
-	  `(fail . ((description . ,description)
-		    (input . ,input)
-		    (output . ,output)
-		    (who . ,procedure))))))))
+   (lambda (k)
+     (with-exception-handler
+	 (lambda (e)
+	   (k `(pass . ,description)))
+       (lambda ()
+	 (test-run-solution procedure input)
+	 `(fail . ((description . ,description)
+		   (input . ,input)
+		   (output . error)
+		   (who . ,procedure))))))))
 
 (define (run-test-suite tests . query)
   (for-each (lambda (field)

--- a/exercises/anagram/test.scm
+++ b/exercises/anagram/test.scm
@@ -31,11 +31,11 @@
       (with-exception-handler
         (lambda (e) (k `(pass . ,description)))
         (lambda ()
-          (test-run-scheme procedure input)
+          (test-run-solution procedure input)
           `(fail
              (description . ,description)
              (input . ,input)
-             (output . ,output)
+             (output . error)
              (who . ,procedure)))))))
 
 (define (run-test-suite tests . query)

--- a/exercises/atbash-cipher/test.scm
+++ b/exercises/atbash-cipher/test.scm
@@ -31,11 +31,11 @@
       (with-exception-handler
         (lambda (e) (k `(pass . ,description)))
         (lambda ()
-          (test-run-scheme procedure input)
+          (test-run-solution procedure input)
           `(fail
              (description . ,description)
              (input . ,input)
-             (output . ,output)
+             (output . error)
              (who . ,procedure)))))))
 
 (define (run-test-suite tests . query)

--- a/exercises/difference-of-squares/test.scm
+++ b/exercises/difference-of-squares/test.scm
@@ -31,11 +31,11 @@
       (with-exception-handler
         (lambda (e) (k `(pass . ,description)))
         (lambda ()
-          (test-run-scheme procedure input)
+          (test-run-solution procedure input)
           `(fail
              (description . ,description)
              (input . ,input)
-             (output . ,output)
+             (output . error)
              (who . ,procedure)))))))
 
 (define (run-test-suite tests . query)

--- a/exercises/grains/test.scm
+++ b/exercises/grains/test.scm
@@ -31,11 +31,11 @@
       (with-exception-handler
         (lambda (e) (k `(pass . ,description)))
         (lambda ()
-          (test-run-scheme procedure input)
+          (test-run-solution procedure input)
           `(fail
              (description . ,description)
              (input . ,input)
-             (output . ,output)
+             (output . error)
              (who . ,procedure)))))))
 
 (define (run-test-suite tests . query)

--- a/exercises/hamming/test.scm
+++ b/exercises/hamming/test.scm
@@ -31,11 +31,11 @@
       (with-exception-handler
         (lambda (e) (k `(pass . ,description)))
         (lambda ()
-          (test-run-scheme procedure input)
+          (test-run-solution procedure input)
           `(fail
              (description . ,description)
              (input . ,input)
-             (output . ,output)
+             (output . error)
              (who . ,procedure)))))))
 
 (define (run-test-suite tests . query)

--- a/exercises/hello-world/test.scm
+++ b/exercises/hello-world/test.scm
@@ -31,11 +31,11 @@
       (with-exception-handler
         (lambda (e) (k `(pass . ,description)))
         (lambda ()
-          (test-run-scheme procedure input)
+          (test-run-solution procedure input)
           `(fail
              (description . ,description)
              (input . ,input)
-             (output . ,output)
+             (output . error)
              (who . ,procedure)))))))
 
 (define (run-test-suite tests . query)

--- a/exercises/knapsack/test.scm
+++ b/exercises/knapsack/test.scm
@@ -31,11 +31,11 @@
       (with-exception-handler
         (lambda (e) (k `(pass . ,description)))
         (lambda ()
-          (test-run-scheme procedure input)
+          (test-run-solution procedure input)
           `(fail
              (description . ,description)
              (input . ,input)
-             (output . ,output)
+             (output . error)
              (who . ,procedure)))))))
 
 (define (run-test-suite tests . query)

--- a/exercises/leap/test.scm
+++ b/exercises/leap/test.scm
@@ -31,11 +31,11 @@
       (with-exception-handler
         (lambda (e) (k `(pass . ,description)))
         (lambda ()
-          (test-run-scheme procedure input)
+          (test-run-solution procedure input)
           `(fail
              (description . ,description)
              (input . ,input)
-             (output . ,output)
+             (output . error)
              (who . ,procedure)))))))
 
 (define (run-test-suite tests . query)

--- a/exercises/nucleotide-count/test.scm
+++ b/exercises/nucleotide-count/test.scm
@@ -31,11 +31,11 @@
       (with-exception-handler
         (lambda (e) (k `(pass . ,description)))
         (lambda ()
-          (test-run-scheme procedure input)
+          (test-run-solution procedure input)
           `(fail
              (description . ,description)
              (input . ,input)
-             (output . ,output)
+             (output . error)
              (who . ,procedure)))))))
 
 (define (run-test-suite tests . query)

--- a/exercises/pascals-triangle/test.scm
+++ b/exercises/pascals-triangle/test.scm
@@ -31,11 +31,11 @@
       (with-exception-handler
         (lambda (e) (k `(pass . ,description)))
         (lambda ()
-          (test-run-scheme procedure input)
+          (test-run-solution procedure input)
           `(fail
              (description . ,description)
              (input . ,input)
-             (output . ,output)
+             (output . error)
              (who . ,procedure)))))))
 
 (define (run-test-suite tests . query)

--- a/exercises/phone-number/example.scm
+++ b/exercises/phone-number/example.scm
@@ -23,7 +23,10 @@
 
 (define (clean phone-number)
   (let ((cleaned (split-phone-number phone-number)))
-    (when (char=? #\0 (string-ref cleaned 4))
+    (when (or (char=? #\0 (string-ref cleaned 3))
+	      (char=? #\1 (string-ref cleaned 3))
+	      (char=? #\0 (string-ref cleaned 0))
+	      (char=? #\1 (string-ref cleaned 0)))
       (error 'clean "exchange code begins with 0" phone-number))
     cleaned))
 

--- a/exercises/phone-number/test.scm
+++ b/exercises/phone-number/test.scm
@@ -31,11 +31,11 @@
       (with-exception-handler
         (lambda (e) (k `(pass . ,description)))
         (lambda ()
-          (test-run-scheme procedure input)
+          (test-run-solution procedure input)
           `(fail
              (description . ,description)
              (input . ,input)
-             (output . ,output)
+             (output . error)
              (who . ,procedure)))))))
 
 (define (run-test-suite tests . query)

--- a/exercises/raindrops/test.scm
+++ b/exercises/raindrops/test.scm
@@ -31,11 +31,11 @@
       (with-exception-handler
         (lambda (e) (k `(pass . ,description)))
         (lambda ()
-          (test-run-scheme procedure input)
+          (test-run-solution procedure input)
           `(fail
              (description . ,description)
              (input . ,input)
-             (output . ,output)
+             (output . error)
              (who . ,procedure)))))))
 
 (define (run-test-suite tests . query)

--- a/exercises/rna-transcription/test.scm
+++ b/exercises/rna-transcription/test.scm
@@ -31,11 +31,11 @@
       (with-exception-handler
         (lambda (e) (k `(pass . ,description)))
         (lambda ()
-          (test-run-scheme procedure input)
+          (test-run-solution procedure input)
           `(fail
              (description . ,description)
              (input . ,input)
-             (output . ,output)
+             (output . error)
              (who . ,procedure)))))))
 
 (define (run-test-suite tests . query)

--- a/exercises/scrabble-score/test.scm
+++ b/exercises/scrabble-score/test.scm
@@ -31,11 +31,11 @@
       (with-exception-handler
         (lambda (e) (k `(pass . ,description)))
         (lambda ()
-          (test-run-scheme procedure input)
+          (test-run-solution procedure input)
           `(fail
              (description . ,description)
              (input . ,input)
-             (output . ,output)
+             (output . error)
              (who . ,procedure)))))))
 
 (define (run-test-suite tests . query)

--- a/exercises/two-fer/test.scm
+++ b/exercises/two-fer/test.scm
@@ -31,11 +31,11 @@
       (with-exception-handler
         (lambda (e) (k `(pass . ,description)))
         (lambda ()
-          (test-run-scheme procedure input)
+          (test-run-solution procedure input)
           `(fail
              (description . ,description)
              (input . ,input)
-             (output . ,output)
+             (output . error)
              (who . ,procedure)))))))
 
 (define (run-test-suite tests . query)

--- a/exercises/word-count/test.scm
+++ b/exercises/word-count/test.scm
@@ -31,11 +31,11 @@
       (with-exception-handler
         (lambda (e) (k `(pass . ,description)))
         (lambda ()
-          (test-run-scheme procedure input)
+          (test-run-solution procedure input)
           `(fail
              (description . ,description)
              (input . ,input)
-             (output . ,output)
+             (output . error)
              (who . ,procedure)))))))
 
 (define (run-test-suite tests . query)


### PR DESCRIPTION
`test-error` referenced an unbound variable, so the test cases generously always failed. This fixes that