### PR TITLE
update running tests hints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,6 @@ track-requirements := \
 	closet/skeleton-makefile \
 	closet/specifications.fasl \
 	closet/config.fasl \
-	closet/track-configs.fasl \
 	$(readme-splice) \
 	$(exercisms) \
 	config.json
@@ -72,7 +71,7 @@ closet/specifications.fasl : ../problem-specifications
 closet/tracks.html :
 	wget https://exercism.io/tracks -O $@
 
-closet/tracks.txt : closet/tracks.html script/fetch-tracks.sh
+closet/tracks.txt : # closet/tracks.html script/fetch-tracks.sh
 	./script/fetch-tracks.sh $< $@
 
 closet/track-configs.fasl : closet/tracks.txt
@@ -115,4 +114,3 @@ clean :
 	rm ci
 
 .PHONY : track clean
-

--- a/code/markdown.sls
+++ b/code/markdown.sls
@@ -49,11 +49,17 @@
                        (inline-code "make chez")
                        " if you're using ChezScheme or "
                        (inline-code "make guile")
-                       " if you're using GNU Guile."))
+                       " if you're using GNU Guile.")
+             (sentence "Sometimes the name for the scheme binary on your system will differ from the defaults.")
+             (sentence "When this is the case, you'll need to tell make by running "
+                       (inline-code "make chez chez=your-chez-binary")
+                       " or "
+                       (inline-code "make guile guile=your-guile-binary")
+                       "."))
             (subsection
              "From a REPL"
              (enum
-              (item "Enter " (inline-code "test.scm") " at the repl prompt.")
+              (item "Enter " (inline-code "(load \"test.scm\")") " at the repl prompt.")
               (item "Develop your solution in "
                     (inline-code ,(format "~a.scm" exercism))
                     " reloading as you go.")
@@ -82,12 +88,12 @@
           ((strike-through) `("~~" ,@(sxml->md content) "~~"))
           ((code) `("```" ,(car content) "\n" ,(cdr content) "\n" "```"))
           ((inline-code) `("`" ,content "`"))
-          ((h1) `("\n\n" "# " ,@(sxml->md content) "\n"))
-          ((h2) `("\n\n" "## " ,@(sxml->md content) "\n"))
-          ((h3) `("\n\n" "### " ,@(sxml->md content) "\n"))
-          ((h4) `("\n\n" "#### " ,@(sxml->md content) "\n"))
-          ((h5) `("\n\n" "##### " ,@(sxml->md content) "\n"))
-          ((h6) `("\n\n" "###### " ,@(sxml->md content) "\n"))
+          ((h1) `("\n" "# " ,@(sxml->md content) "\n"))
+          ((h2) `("\n" "## " ,@(sxml->md content) "\n"))
+          ((h3) `("\n" "### " ,@(sxml->md content) "\n"))
+          ((h4) `("\n" "#### " ,@(sxml->md content) "\n"))
+          ((h5) `("\n" "##### " ,@(sxml->md content) "\n"))
+          ((h6) `("\n" "###### " ,@(sxml->md content) "\n"))
           ((item) `("* " ,@(sxml->md content) "\n"))
           ((enum) `(,@(sxml->md content) "\n"))
           ((nl) "\n")

--- a/config/exercise-readme-insert.md
+++ b/config/exercise-readme-insert.md
@@ -1,13 +1,10 @@
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
 
 ### From a REPL
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,13 +1,10 @@
 
-
 ## Installing a scheme
-
 
 
 ### ChezScheme
 
 Follow the instructions at [ChezScheme](https://cisco.github.io/ChezScheme/#get)\.
-
 
 ### GNU Guile
 

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,7 +1,5 @@
 
-
 ## Recommended Resources
-
 
 
 ### Books
@@ -10,18 +8,15 @@
 * [The Scheme Programming Language](https://www.scheme.com/tspl4/)
 
 
-
 ### YouTube
 
 * [Structure and Interpretation of Computer Programs](https://www.youtube.com/watch?v=-J_xL4IGhJA&list=PLE18841CABEA24090)
-
 
 
 ### Manuals
 
 * [ChezScheme](http://cisco.github.io/ChezScheme/csug9.5/csug.html)
 * [GNU Guile](https://www.gnu.org/software/guile/manual/)
-
 
 
 ### Miscellaneous
@@ -32,12 +27,10 @@
 * ['(schemers . org)](https://schemers.org/)
 
 
-
 ## Online Courses
 
 * [Structure and Interpretation of Computer Programs](https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-001-structure-and-interpretation-of-computer-programs-spring-2005/)
 * [Coursera CS 341](https://www.coursera.org/learn/programming-languages-part-b)
-
 
 
 ### Emacs modes

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,13 +1,10 @@
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
 
 ### From a REPL
 

--- a/exercises/affine-cipher/.meta/hints.md
+++ b/exercises/affine-cipher/.meta/hints.md
@@ -1,17 +1,16 @@
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `affine-cipher.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/affine-cipher/README.md
+++ b/exercises/affine-cipher/README.md
@@ -70,19 +70,18 @@ harder to guess things based on word boundaries.
     - `7` is the MMI of `15 mod 26`
 
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `affine-cipher.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/anagram/.meta/hints.md
+++ b/exercises/anagram/.meta/hints.md
@@ -1,24 +1,22 @@
 
-
 ## Track Specific Notes
 
 For purposes
 of this exercise, a word is not considered to be an anagram of
 itself\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `anagram.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -8,26 +8,24 @@ Given `"listen"` and a list of candidates like `"enlists" "google"
 `"inlets"`.
 
 
-
 ## Track Specific Notes
 
 For purposes
 of this exercise, a word is not considered to be an anagram of
 itself\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `anagram.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/atbash-cipher/.meta/hints.md
+++ b/exercises/atbash-cipher/.meta/hints.md
@@ -1,17 +1,16 @@
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `atbash-cipher.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -29,19 +29,18 @@ things based on word boundaries.
 - Decoding `gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt` gives `thequickbrownfoxjumpsoverthelazydog`
 
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `atbash-cipher.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/binary-search/.meta/hints.md
+++ b/exercises/binary-search/.meta/hints.md
@@ -1,23 +1,21 @@
 
-
 ## Track Specific Notes
 
 If the element is not present in the array, return the symbol `'not-found`\.
 The array will be passed as a vector\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `binary-search.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/binary-search/README.md
+++ b/exercises/binary-search/README.md
@@ -35,25 +35,23 @@ so locating an item (or determining its absence) takes logarithmic time.
 A binary search is a dichotomic divide and conquer search algorithm.
 
 
-
 ## Track Specific Notes
 
 If the element is not present in the array, return the symbol `'not-found`\.
 The array will be passed as a vector\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `binary-search.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/bob/.meta/hints.md
+++ b/exercises/bob/.meta/hints.md
@@ -1,23 +1,21 @@
 
-
 ## Track Specific Notes
 
 See if you can
 clearly separate responsibilities in your code\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `bob.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -16,25 +16,23 @@ He answers 'Whatever.' to anything else.
 Bob's conversational partner is a purist when it comes to written communication and always follows normal rules regarding sentence punctuation in English.
 
 
-
 ## Track Specific Notes
 
 See if you can
 clearly separate responsibilities in your code\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `bob.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/change/.meta/hints.md
+++ b/exercises/change/.meta/hints.md
@@ -1,17 +1,16 @@
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `change.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/change/README.md
+++ b/exercises/change/README.md
@@ -17,19 +17,18 @@ that the sum of the coins' value would equal the correct amount of change.
 - Can you ask for a change value smaller than the smallest coin value?
 
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `change.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/collatz-conjecture/.meta/hints.md
+++ b/exercises/collatz-conjecture/.meta/hints.md
@@ -1,22 +1,20 @@
 
-
 ## Track Specific Notes
 
 Don't worry about validating input for this track \-\- all inputs will be natural numbers\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `collatz-conjecture.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/collatz-conjecture/README.md
+++ b/exercises/collatz-conjecture/README.md
@@ -27,24 +27,22 @@ Starting with n = 12, the steps would be as follows:
 Resulting in 9 steps. So for input n = 12, the return value would be 9.
 
 
-
 ## Track Specific Notes
 
 Don't worry about validating input for this track \-\- all inputs will be natural numbers\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `collatz-conjecture.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/difference-of-squares/.meta/hints.md
+++ b/exercises/difference-of-squares/.meta/hints.md
@@ -1,17 +1,16 @@
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `difference-of-squares.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -17,19 +17,18 @@ first principles; research is allowed, indeed, encouraged. Finding the best
 algorithm for the problem is a key skill in software engineering.
 
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `difference-of-squares.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/forth/.meta/hints.md
+++ b/exercises/forth/.meta/hints.md
@@ -1,24 +1,22 @@
 
-
 ## Track Specific Notes
 
 The input is presented as a list of strings\.
 Definitions are presented as `: var x ... ;` where `var` is bound to what follows\.
 Otherwise the string represents a sequence of stack manipulations\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `forth.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/forth/README.md
+++ b/exercises/forth/README.md
@@ -26,26 +26,24 @@ enough.)
 Words are case-insensitive.
 
 
-
 ## Track Specific Notes
 
 The input is presented as a list of strings\.
 Definitions are presented as `: var x ... ;` where `var` is bound to what follows\.
 Otherwise the string represents a sequence of stack manipulations\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `forth.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/grains/.meta/hints.md
+++ b/exercises/grains/.meta/hints.md
@@ -1,23 +1,21 @@
 
-
 ## Track Specific Notes
 
 The tests expect an error to be reported for out of
 range inputs\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `grains.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -27,25 +27,23 @@ Then please share your thoughts in a comment on the submission. Did this
 experiment make the code better? Worse? Did you learn anything from it?
 
 
-
 ## Track Specific Notes
 
 The tests expect an error to be reported for out of
 range inputs\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `grains.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/hamming/.meta/hints.md
+++ b/exercises/hamming/.meta/hints.md
@@ -1,22 +1,20 @@
 
-
 ## Track Specific Notes
 
 For scheme, you may want to look into one of `error`, `assert`, or `raise`\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `hamming.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -24,24 +24,22 @@ not work. The general handling of this situation (e.g., raising an
 exception vs returning a special value) may differ between languages.
 
 
-
 ## Track Specific Notes
 
 For scheme, you may want to look into one of `error`, `assert`, or `raise`\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `hamming.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/hello-world/.meta/hints.md
+++ b/exercises/hello-world/.meta/hints.md
@@ -1,24 +1,22 @@
 
-
 ## Track Specific Notes
 
 Your solution may be a procedure that
 returns the desired string or a variable whose value is that
 string\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `hello-world.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -15,26 +15,24 @@ The objectives are simple:
 If everything goes well, you will be ready to fetch your first real exercise.
 
 
-
 ## Track Specific Notes
 
 Your solution may be a procedure that
 returns the desired string or a variable whose value is that
 string\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `hello-world.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/knapsack/.meta/hints.md
+++ b/exercises/knapsack/.meta/hints.md
@@ -1,24 +1,22 @@
 
-
 ## Track Specific Notes
 
 In the scheme version the aruguments are the `capacity` of the knapsack and a list of the `weights` and a list of the `values`\.
 It won't be necessary to validate the input \-\- the
 test inputs have valid values and same length lists\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `knapsack.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/knapsack/README.md
+++ b/exercises/knapsack/README.md
@@ -37,26 +37,24 @@ value, which, in this case, is 90. He cannot get more than 90 as his
 knapsack has a weight limit of 10.
 
 
-
 ## Track Specific Notes
 
 In the scheme version the aruguments are the `capacity` of the knapsack and a list of the `weights` and a list of the `values`\.
 It won't be necessary to validate the input \-\- the
 test inputs have valid values and same length lists\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `knapsack.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/leap/.meta/hints.md
+++ b/exercises/leap/.meta/hints.md
@@ -1,17 +1,16 @@
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `leap.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -24,19 +24,18 @@ phenomenon, go watch [this youtube video][video].
 [video]: http://www.youtube.com/watch?v=xX96xng7sAE
 
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `leap.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/matching-brackets/.meta/hints.md
+++ b/exercises/matching-brackets/.meta/hints.md
@@ -1,17 +1,16 @@
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `matching-brackets.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/matching-brackets/README.md
+++ b/exercises/matching-brackets/README.md
@@ -5,19 +5,18 @@ or any combination thereof, verify that any and all pairs are matched
 and nested correctly.
 
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `matching-brackets.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/nucleotide-count/.meta/hints.md
+++ b/exercises/nucleotide-count/.meta/hints.md
@@ -1,17 +1,16 @@
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `nucleotide-count.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -13,19 +13,18 @@ Here is an analogy:
 - words are to sentences as...
 
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `nucleotide-count.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/pangram/.meta/hints.md
+++ b/exercises/pangram/.meta/hints.md
@@ -1,23 +1,21 @@
 
-
 ## Track Specific Notes
 
 Consider inputs case insensitive
 and allow more than one of each required char\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `pangram.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -9,25 +9,23 @@ The alphabet used consists of ASCII letters `a` to `z`, inclusive, and is case
 insensitive. Input will not contain non-ASCII symbols.
 
 
-
 ## Track Specific Notes
 
 Consider inputs case insensitive
 and allow more than one of each required char\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `pangram.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/pascals-triangle/.meta/hints.md
+++ b/exercises/pascals-triangle/.meta/hints.md
@@ -1,17 +1,16 @@
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `pascals-triangle.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/pascals-triangle/README.md
+++ b/exercises/pascals-triangle/README.md
@@ -15,19 +15,18 @@ the right and left of the current position in the previous row.
 ```
 
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `pascals-triangle.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/perfect-numbers/.meta/hints.md
+++ b/exercises/perfect-numbers/.meta/hints.md
@@ -1,17 +1,16 @@
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `perfect-numbers.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/perfect-numbers/README.md
+++ b/exercises/perfect-numbers/README.md
@@ -18,19 +18,18 @@ The Greek mathematician [Nicomachus](https://en.wikipedia.org/wiki/Nicomachus) d
 Implement a way to determine whether a given number is **perfect**. Depending on your language track, you may also need to implement a way to determine whether a given number is **abundant** or **deficient**.
 
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `perfect-numbers.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/phone-number/.meta/hints.md
+++ b/exercises/phone-number/.meta/hints.md
@@ -1,17 +1,16 @@
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `phone-number.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -29,19 +29,18 @@ should all produce the output
 **Note:** As this exercise only deals with telephone numbers used in NANP-countries, only 1 is considered a valid country code.
 
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `phone-number.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/prime-factors/.meta/hints.md
+++ b/exercises/prime-factors/.meta/hints.md
@@ -1,17 +1,16 @@
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `prime-factors.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/prime-factors/README.md
+++ b/exercises/prime-factors/README.md
@@ -30,19 +30,18 @@ You can check this yourself:
 - Success!
 
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `prime-factors.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/queen-attack/.meta/hints.md
+++ b/exercises/queen-attack/.meta/hints.md
@@ -1,24 +1,22 @@
 
-
 ## Track Specific Notes
 
 For this track, each queen's position will be represented as a list
 containing the row and the column\.
 You should assume all inputs are valid, there's no need to report errors\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `queen-attack.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/queen-attack/README.md
+++ b/exercises/queen-attack/README.md
@@ -27,26 +27,24 @@ In this case, that answer would be yes, they can, because both pieces
 share a diagonal.
 
 
-
 ## Track Specific Notes
 
 For this track, each queen's position will be represented as a list
 containing the row and the column\.
 You should assume all inputs are valid, there's no need to report errors\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `queen-attack.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/raindrops/.meta/hints.md
+++ b/exercises/raindrops/.meta/hints.md
@@ -1,17 +1,16 @@
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `raindrops.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -16,19 +16,18 @@ The rules of `raindrops` are that if a given number:
 - 34 is not factored by 3, 5, or 7, so the result would be "34".
 
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `raindrops.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/rna-transcription/.meta/hints.md
+++ b/exercises/rna-transcription/.meta/hints.md
@@ -1,17 +1,16 @@
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `rna-transcription.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -19,19 +19,18 @@ each nucleotide with its complement:
 * `A` -> `U`
 
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `rna-transcription.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/rotational-cipher/.meta/hints.md
+++ b/exercises/rotational-cipher/.meta/hints.md
@@ -1,17 +1,16 @@
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `rotational-cipher.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -31,19 +31,18 @@ Ciphertext is written out in the same formatting as the input including spaces a
 - ROT13 `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.` gives `The quick brown fox jumps over the lazy dog.`
 
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `rotational-cipher.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/scrabble-score/.meta/hints.md
+++ b/exercises/scrabble-score/.meta/hints.md
@@ -1,17 +1,16 @@
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `scrabble-score.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -40,19 +40,18 @@ And to total:
 - You can play a double or a triple word.
 
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `scrabble-score.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/sieve/.meta/hints.md
+++ b/exercises/sieve/.meta/hints.md
@@ -1,17 +1,16 @@
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `sieve.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -30,19 +30,18 @@ division or remainder operations (div, /, mod or % depending on the
 language).
 
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `sieve.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/transpose/.meta/hints.md
+++ b/exercises/transpose/.meta/hints.md
@@ -1,17 +1,16 @@
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `transpose.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/transpose/README.md
+++ b/exercises/transpose/README.md
@@ -59,19 +59,18 @@ That means that if a column in the input text contains only spaces on its bottom
 the corresponding output row should contain the spaces in its right-most column(s).
 
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `transpose.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/two-fer/.meta/hints.md
+++ b/exercises/two-fer/.meta/hints.md
@@ -1,23 +1,21 @@
 
-
 ## Track Specific Notes
 
 One way to get optional arguments in scheme is by specifying the arguments as a list\.
 Two ways to do that are: `(define (two-fer . args) ...)` or `(define two-fer (lambda args ...))`\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `two-fer.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -26,25 +26,23 @@ Here are some examples:
 |Zaphod  |One for Zaphod, one for me.
 
 
-
 ## Track Specific Notes
 
 One way to get optional arguments in scheme is by specifying the arguments as a list\.
 Two ways to do that are: `(define (two-fer . args) ...)` or `(define two-fer (lambda args ...))`\.
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `two-fer.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/word-count/.meta/hints.md
+++ b/exercises/word-count/.meta/hints.md
@@ -1,17 +1,16 @@
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `word-count.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -31,19 +31,18 @@ fled: 1
 ```
 
 
-
 ## Running and testing your solutions
-
 
 
 ### From the command line
 
 Simply type `make chez` if you're using ChezScheme or `make guile` if you're using GNU Guile\.
-
+Sometimes the name for the scheme binary on your system will differ from the defaults\.
+When this is the case, you'll need to tell make by running `make chez chez=your-chez-binary` or `make guile guile=your-guile-binary`\.
 
 ### From a REPL
 
-* Enter `test.scm` at the repl prompt\.
+* Enter `(load "test.scm")` at the repl prompt\.
 * Develop your solution in `word-count.scm` reloading as you go\.
 * Run `(test)` to check your solution\.
 


### PR DESCRIPTION
A student had issues where they had mit scheme installed and their chez binary wasn't named `scheme`. The makefile allows for this, but how to deal with it was not communicated in the readme. This addresses that.