### PR TITLE
config.json: Add missing `core` key; Run `configlet fmt`

### DIFF
--- a/config.json
+++ b/config.json
@@ -339,7 +339,7 @@
     {
       "slug": "collatz-conjecture",
       "uuid": "dbab5247-54d1-4830-a159-655397bd91e4",
-      "auto_approve": false,
+      "core": false,
       "unlocked_by": "grains",
       "difficulty": 1,
       "topics": [

--- a/config.json
+++ b/config.json
@@ -125,8 +125,8 @@
       "core": false,
       "unlocked_by": "anagram",
       "difficulty": 1,
-      "deprecated": true,
-      "topics": null
+      "topics": null,
+      "deprecated": true
     },
     {
       "slug": "phone-number",
@@ -155,8 +155,8 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
-      "deprecated": true,
-      "topics": null
+      "topics": null,
+      "deprecated": true
     },
     {
       "slug": "scrabble-score",
@@ -306,35 +306,35 @@
       "uuid": "fa78d295-adc0-41ae-bfe2-4a6eb8c40f9d",
       "core": false,
       "unlocked_by": "leap",
+      "difficulty": 5,
       "topics": [
         "fold",
         "parsing",
         "stack",
         "string"
-      ],
-      "difficulty": 5
+      ]
     },
     {
       "slug": "queen-attack",
       "uuid": "c38e9025-4b47-41ef-a91a-5ca9cca2a91f",
       "core": false,
       "unlocked_by": "hamming",
+      "difficulty": 2,
       "topics": [
         "chess"
-      ],
-      "difficulty": 2
+      ]
     },
     {
       "slug": "forth",
       "uuid": "09cb9d2b-3a04-4685-95d5-10fe0128be8f",
       "core": false,
       "unlocked_by": "hello-world",
+      "difficulty": 8,
       "topics": [
         "interpreter",
         "language",
         "stack_machine"
-      ],
-      "difficulty": 8
+      ]
     },
     {
       "slug": "collatz-conjecture",

--- a/config/track.ss
+++ b/config/track.ss
@@ -240,7 +240,7 @@
 
  ((slug . collatz-conjecture)
   (uuid . "dbab5247-54d1-4830-a159-655397bd91e4")
-  (auto-approve . #f)
+  (core . #f)
   (unlocked-by . grains)
   (difficulty . 1)
   (topics math recursion))

--- a/config/track.ss
+++ b/config/track.ss
@@ -92,8 +92,8 @@
   (core . #f)
   (unlocked-by . anagram)
   (difficulty . 1)
-  (deprecated . #t)
-  (topics))
+  (topics)
+  (deprecated . #t))
 
  ((slug . phone-number)
   (uuid . "8ed74044-2361-459e-aca5-abd73ed5c1cb")
@@ -114,8 +114,8 @@
   (core . #f)
   (unlocked-by)
   (difficulty . 1)
-  (deprecated . #t)
-  (topics))
+  (topics)
+  (deprecated . #t))
 
  ((slug . scrabble-score)
   (uuid . "5b44ccd4-b1f4-4b86-89c8-f1dec5905ccb")
@@ -216,27 +216,27 @@
   (unlocked-by . hamming)
   (difficulty . 2)
   (topics string))
- 
+
  ((slug . matching-brackets)
   (uuid . "fa78d295-adc0-41ae-bfe2-4a6eb8c40f9d")
   (core . #f)
   (unlocked-by . leap)
-  (topics string stack fold parsing)
-  (difficulty . 5))
+  (difficulty . 5)
+  (topics string stack fold parsing))
 
  ((slug . queen-attack)
   (uuid . "c38e9025-4b47-41ef-a91a-5ca9cca2a91f")
   (core . #f)
   (unlocked-by . hamming)
-  (topics chess)
-  (difficulty . 2))
+  (difficulty . 2)
+  (topics chess))
 
  ((slug . forth)
   (uuid . "09cb9d2b-3a04-4685-95d5-10fe0128be8f")
   (core . #f)
   (unlocked-by . hello-world)
-  (topics stack-machine interpreter language)
-  (difficulty . 8))
+  (difficulty . 8)
+  (topics stack-machine interpreter language))
 
  ((slug . collatz-conjecture)
   (uuid . "dbab5247-54d1-4830-a159-655397bd91e4")
@@ -244,5 +244,5 @@
   (unlocked-by . grains)
   (difficulty . 1)
   (topics math recursion))
- 
+
  )


### PR DESCRIPTION
Summary:
- Add missing `core` key to `collatz-conjecture`.
- Run `configlet fmt`.

I'm making this PR because I noticed that the Scheme track is currently the only track with an exercise that lacks a `core` key.

Feel free to squash these commits if desired.