### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 Scheme is a statically scoped and properly tail\-recursive dialect of the Lisp programming language invented by Guy Lewis Steele Jr\. and Gerald Jay Sussman\.
 It was designed to have an exceptionally clear and simple semantics and few different ways to form expressions\.
 A wide variety of programming paradigms, including functional, imperative, and message passing styles, find convenient expression in Scheme\.

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
 
 ## Recommended Resources
 

--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 
 ## Track Specific Notes
 

--- a/exercises/practice/binary-search/.docs/instructions.append.md
+++ b/exercises/practice/binary-search/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 
 ## Track Specific Notes
 

--- a/exercises/practice/bob/.docs/instructions.append.md
+++ b/exercises/practice/bob/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 
 ## Track Specific Notes
 

--- a/exercises/practice/collatz-conjecture/.docs/instructions.append.md
+++ b/exercises/practice/collatz-conjecture/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 
 ## Track Specific Notes
 

--- a/exercises/practice/forth/.docs/instructions.append.md
+++ b/exercises/practice/forth/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 
 ## Track Specific Notes
 

--- a/exercises/practice/grains/.docs/instructions.append.md
+++ b/exercises/practice/grains/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 
 ## Track Specific Notes
 

--- a/exercises/practice/hamming/.docs/instructions.append.md
+++ b/exercises/practice/hamming/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 
 ## Track Specific Notes
 

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 
 ## Track Specific Notes
 

--- a/exercises/practice/knapsack/.docs/instructions.append.md
+++ b/exercises/practice/knapsack/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 
 ## Track Specific Notes
 

--- a/exercises/practice/pangram/.docs/instructions.append.md
+++ b/exercises/practice/pangram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 
 ## Track Specific Notes
 

--- a/exercises/practice/queen-attack/.docs/instructions.append.md
+++ b/exercises/practice/queen-attack/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 
 ## Track Specific Notes
 

--- a/exercises/practice/two-fer/.docs/instructions.append.md
+++ b/exercises/practice/two-fer/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 
 ## Track Specific Notes
 


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
