### PR TITLE
🤖 Add file patterns to config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -14,6 +14,20 @@
     "indent_style": "space",
     "indent_size": 4
   },
+  "files": {
+    "solution": [
+      "%{kebab_slug}.scm"
+    ],
+    "test": [
+      "test.scm"
+    ],
+    "example": [
+      "example.scm"
+    ],
+    "exemplar": [
+      ".meta/exemplar.scm"
+    ]
+  },
   "exercises": {
     "concept": [],
     "practice": [


### PR DESCRIPTION
**⚠ This PR requires you to make a simple change before merging. ⚠**

---

To save maintainers from having to manually specify the `files` key in their exercises' `.meta/config.json` files, we are providing support for track-level patterns. See [this PR](https://github.com/exercism/docs/pull/58) for details.

This PR adds (**purposefully wrong**) file patterns to the `config.json` file. It is up to you, the track maintainers, to change these patterns to their correct value.

You can use the following placeholders:
- `%{kebab_slug}`: the `kebab-case` exercise slug (e.g. `bit-manipulation`)
- `%{snake_slug}`: the `snake_case` exercise slug (e.g. `bit_manipulation`)
- `%{camel_slug}`: the `camelCase` exercise slug (e.g. `bitManipulation`)
- `%{pascal_slug}`: the `PascalCase` exercise slug (e.g. `BitManipulation`)

We will soon update `configlet` to enable it to automatically populate the `.meta/config.json` file's `files` property, at which point we will then batch-PR updates to all tracks that have merged this PR.

## Tracking
https://github.com/exercism/v3-launch/issues/19
