### PR TITLE
🤖 Add blurb to .meta/config.json files

### DIFF
--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Convert a long phrase to its acronym",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/affine-cipher/.meta/config.json
+++ b/exercises/practice/affine-cipher/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Create an implementation of the Affine cipher, an ancient encryption algorithm from the Middle East.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Determine if a number is an Armstrong number",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Implement a binary search algorithm.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/change/.meta/config.json
+++ b/exercises/practice/change/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Correctly determine change to be given using the least number of coins",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Implement an evaluator for a very simple subset of Forth",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Calculate the Hamming difference between two DNA strands.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/knapsack/.meta/config.json
+++ b/exercises/practice/knapsack/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a knapsack that can only carry a certain weight, determine which items to put in the knapsack in order to maximize their combined value.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a year, report if it is a leap year.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Implement basic list operations",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Make sure the brackets and braces all match.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/octal/.meta/config.json
+++ b/exercises/practice/octal/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Convert a octal number, represented as a string (e.g. '1735263'), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Determine if a sentence is a pangram.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Compute Pascal's triangle up to a given number of rows.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Clean up user-entered phone numbers so that they can be sent SMS messages.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Compute the prime factors of a given natural number.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Manage robot factory settings.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/rotational-cipher/.meta/config.json
+++ b/exercises/practice/rotational-cipher/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a word, compute the Scrabble score for that word.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Use the Sieve of Eratosthenes to find all the primes from 2 up to a given number.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a number, find the sum of all the multiples of particular numbers up to but not including that number.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/transpose/.meta/config.json
+++ b/exercises/practice/transpose/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Take input text and output it transposed.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/trinary/.meta/config.json
+++ b/exercises/practice/trinary/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Convert a trinary number, represented as a string (e.g. '102012'), to its decimal equivalent using first principles.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Create a sentence of the form \"One for X, one for me.\"",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a phrase, count the occurrences of each word in that phrase.",
   "authors": [],
   "files": {
     "solution": [],


### PR DESCRIPTION
Each Concept and Practice Exercise will have to define a _blurb_, which is a short description of the exercise.
The blurb will be displayed on a track's exercises page and on exercise tooltips. For example:

<img width="1194" alt="Screenshot 2021-03-02 at 13 25 38" src="https://user-images.githubusercontent.com/286476/109655154-da058500-7b5a-11eb-8346-bf733a72b3d0.png">
<img width="400" alt="Screenshot 2021-03-02 at 13 25 51" src="https://user-images.githubusercontent.com/286476/109655162-dd007580-7b5a-11eb-88f8-582532be9b84.png">

Blurbs must be limited to 350 chars and will be truncated in some views.

For Practice Exercises that are based on an exercise defined in the problem-specification repo, the blurb must match the contents of the problem-specifications exercises, which is defined in its `metadata.yml` file. In this PR, we'll do an initial syncing of the blurb. The new [configlet](https://github.com/exercism/configlet) version will add support for doing this syncing automatically.

If the Practice Exercise was _not_ based on a problems-specifications exercise, we've used the blurb from its `.meta/metadata.yml` file as the blurb in the .meta/config.json file.

See the [Practice Exercise spec](https://github.com/exercism/docs/blob/main/anatomy/tracks/practice-exercises.md#file-metaconfigjson) for more information.

## Tracking

https://github.com/exercism/v3-launch/issues/21
