### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,25 @@
+{
+  "docs": [
+    {
+      "uuid": "6c5c46c6-fd05-4c1b-ae89-7dbf16b466c4",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Scheme locally",
+      "blurb": "Learn how to install Scheme locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "1528fa64-cf14-4310-a1be-f731c604d34e",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Scheme track",
+      "blurb": "Learn how to test your Scheme exercises on Exercism"
+    },
+    {
+      "uuid": "5e72db99-3bf8-4161-8369-dfba4fdc9596",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Scheme resources",
+      "blurb": "A collection of useful resources to help you master Scheme"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
