### PR TITLE
Accept alists for Word Count results

### DIFF
--- a/exercises/practice/word-count/test.scm
+++ b/exercises/practice/word-count/test.scm
@@ -99,64 +99,36 @@
 (define (run-docker test-cases)
   (write (map (lambda (test) (test)) test-cases)))
 
+(define (matches? result expected)
+  (let ([get-count (if (hashtable? result)
+                     (lambda (word)
+                       (hashtable-ref result word 0))
+                     (lambda (word)
+                       (cond
+                         [(assoc word result) => cdr]
+                         [else 0])))])
+    (and (= (length expected)
+            (if (hashtable? result) (hashtable-size result) (length result)))
+         (fold-left
+           (lambda (count-agrees w.c)
+             (and count-agrees
+                  (= (cdr w.c) (get-count (car w.c)))))
+           #t
+           expected))))
+
 (define word-count)
 
 (define test-cases
   (list
     (lambda ()
-      (test-success "count one word"
-        (lambda (result expected)
-          (let ([get-count (if (hashtable? result)
-                               (lambda (word)
-                                 (hashtable-ref result word 0))
-                               (lambda (word)
-                                 (cond
-                                   [(assoc word result) => cdr]
-                                   [else 0])))])
-            (and (= (length expected) (hashtable-size result))
-                 (fold-left
-                   (lambda (count-agrees w.c)
-                     (and count-agrees
-                          (= (cdr w.c) (get-count (car w.c)))))
-                   #t
-                   expected))))
+      (test-success "count one word" matches?
         word-count '("word") '(("word" . 1))))
     (lambda ()
-      (test-success "count one of each word"
-        (lambda (result expected)
-          (let ([get-count (if (hashtable? result)
-                               (lambda (word)
-                                 (hashtable-ref result word 0))
-                               (lambda (word)
-                                 (cond
-                                   [(assoc word result) => cdr]
-                                   [else 0])))])
-            (and (= (length expected) (hashtable-size result))
-                 (fold-left
-                   (lambda (count-agrees w.c)
-                     (and count-agrees
-                          (= (cdr w.c) (get-count (car w.c)))))
-                   #t
-                   expected))))
+      (test-success "count one of each word" matches?
         word-count '("one of each")
         '(("one" . 1) ("of" . 1) ("each" . 1))))
     (lambda ()
-      (test-success "multiple occurrences of a word"
-        (lambda (result expected)
-          (let ([get-count (if (hashtable? result)
-                               (lambda (word)
-                                 (hashtable-ref result word 0))
-                               (lambda (word)
-                                 (cond
-                                   [(assoc word result) => cdr]
-                                   [else 0])))])
-            (and (= (length expected) (hashtable-size result))
-                 (fold-left
-                   (lambda (count-agrees w.c)
-                     (and count-agrees
-                          (= (cdr w.c) (get-count (car w.c)))))
-                   #t
-                   expected))))
+      (test-success "multiple occurrences of a word" matches?
         word-count '("one fish two fish red fish blue fish")
         '(("one" . 1)
            ("fish" . 4)
@@ -164,60 +136,15 @@
            ("red" . 1)
            ("blue" . 1))))
     (lambda ()
-      (test-success "handles cramped lists"
-        (lambda (result expected)
-          (let ([get-count (if (hashtable? result)
-                               (lambda (word)
-                                 (hashtable-ref result word 0))
-                               (lambda (word)
-                                 (cond
-                                   [(assoc word result) => cdr]
-                                   [else 0])))])
-            (and (= (length expected) (hashtable-size result))
-                 (fold-left
-                   (lambda (count-agrees w.c)
-                     (and count-agrees
-                          (= (cdr w.c) (get-count (car w.c)))))
-                   #t
-                   expected))))
+      (test-success "handles cramped lists" matches?
         word-count '("one,two,three")
         '(("one" . 1) ("two" . 1) ("three" . 1))))
     (lambda ()
-      (test-success "handles expanded lists"
-        (lambda (result expected)
-          (let ([get-count (if (hashtable? result)
-                               (lambda (word)
-                                 (hashtable-ref result word 0))
-                               (lambda (word)
-                                 (cond
-                                   [(assoc word result) => cdr]
-                                   [else 0])))])
-            (and (= (length expected) (hashtable-size result))
-                 (fold-left
-                   (lambda (count-agrees w.c)
-                     (and count-agrees
-                          (= (cdr w.c) (get-count (car w.c)))))
-                   #t
-                   expected))))
+      (test-success "handles expanded lists" matches?
         word-count '("one,\ntwo,\nthree")
         '(("one" . 1) ("two" . 1) ("three" . 1))))
     (lambda ()
-      (test-success "ignore punctuation"
-        (lambda (result expected)
-          (let ([get-count (if (hashtable? result)
-                               (lambda (word)
-                                 (hashtable-ref result word 0))
-                               (lambda (word)
-                                 (cond
-                                   [(assoc word result) => cdr]
-                                   [else 0])))])
-            (and (= (length expected) (hashtable-size result))
-                 (fold-left
-                   (lambda (count-agrees w.c)
-                     (and count-agrees
-                          (= (cdr w.c) (get-count (car w.c)))))
-                   #t
-                   expected))))
+      (test-success "ignore punctuation" matches?
         word-count '("car: carpet as java: javascript!!&@$%^&")
         '(("car" . 1)
            ("carpet" . 1)
@@ -225,60 +152,15 @@
            ("java" . 1)
            ("javascript" . 1))))
     (lambda ()
-      (test-success "include numbers"
-        (lambda (result expected)
-          (let ([get-count (if (hashtable? result)
-                               (lambda (word)
-                                 (hashtable-ref result word 0))
-                               (lambda (word)
-                                 (cond
-                                   [(assoc word result) => cdr]
-                                   [else 0])))])
-            (and (= (length expected) (hashtable-size result))
-                 (fold-left
-                   (lambda (count-agrees w.c)
-                     (and count-agrees
-                          (= (cdr w.c) (get-count (car w.c)))))
-                   #t
-                   expected))))
+      (test-success "include numbers" matches?
         word-count '("testing, 1, 2 testing")
         '(("testing" . 2) ("1" . 1) ("2" . 1))))
     (lambda ()
-      (test-success "normalize case"
-        (lambda (result expected)
-          (let ([get-count (if (hashtable? result)
-                               (lambda (word)
-                                 (hashtable-ref result word 0))
-                               (lambda (word)
-                                 (cond
-                                   [(assoc word result) => cdr]
-                                   [else 0])))])
-            (and (= (length expected) (hashtable-size result))
-                 (fold-left
-                   (lambda (count-agrees w.c)
-                     (and count-agrees
-                          (= (cdr w.c) (get-count (car w.c)))))
-                   #t
-                   expected))))
+      (test-success "normalize case" matches?
         word-count '("go Go GO Stop stop")
         '(("go" . 3) ("stop" . 2))))
     (lambda ()
-      (test-success "with apostrophes"
-        (lambda (result expected)
-          (let ([get-count (if (hashtable? result)
-                               (lambda (word)
-                                 (hashtable-ref result word 0))
-                               (lambda (word)
-                                 (cond
-                                   [(assoc word result) => cdr]
-                                   [else 0])))])
-            (and (= (length expected) (hashtable-size result))
-                 (fold-left
-                   (lambda (count-agrees w.c)
-                     (and count-agrees
-                          (= (cdr w.c) (get-count (car w.c)))))
-                   #t
-                   expected))))
+      (test-success "with apostrophes" matches?
         word-count '("First: don't laugh. Then: don't cry.")
         '(("first" . 1)
            ("don't" . 2)
@@ -286,81 +168,21 @@
            ("then" . 1)
            ("cry" . 1))))
     (lambda ()
-      (test-success "with quotations"
-        (lambda (result expected)
-          (let ([get-count (if (hashtable? result)
-                               (lambda (word)
-                                 (hashtable-ref result word 0))
-                               (lambda (word)
-                                 (cond
-                                   [(assoc word result) => cdr]
-                                   [else 0])))])
-            (and (= (length expected) (hashtable-size result))
-                 (fold-left
-                   (lambda (count-agrees w.c)
-                     (and count-agrees
-                          (= (cdr w.c) (get-count (car w.c)))))
-                   #t
-                   expected))))
-        word-count '("Joe can't tell between 'large' and large.")
+      (test-success "with quotations" matches?
+          word-count '("Joe can't tell between 'large' and large.")
         '(("joe" . 1) ("can't" . 1) ("tell" . 1) ("between" . 1)
            ("large" . 2) ("and" . 1))))
     (lambda ()
-      (test-success "substrings from the beginning"
-        (lambda (result expected)
-          (let ([get-count (if (hashtable? result)
-                               (lambda (word)
-                                 (hashtable-ref result word 0))
-                               (lambda (word)
-                                 (cond
-                                   [(assoc word result) => cdr]
-                                   [else 0])))])
-            (and (= (length expected) (hashtable-size result))
-                 (fold-left
-                   (lambda (count-agrees w.c)
-                     (and count-agrees
-                          (= (cdr w.c) (get-count (car w.c)))))
-                   #t
-                   expected))))
+      (test-success "substrings from the beginning" matches?
         word-count '("Joe can't tell between app, apple and a.")
         '(("joe" . 1) ("can't" . 1) ("tell" . 1) ("between" . 1)
            ("app" . 1) ("apple" . 1) ("and" . 1) ("a" . 1))))
     (lambda ()
-      (test-success "multiple spaces not detected as a word"
-        (lambda (result expected)
-          (let ([get-count (if (hashtable? result)
-                               (lambda (word)
-                                 (hashtable-ref result word 0))
-                               (lambda (word)
-                                 (cond
-                                   [(assoc word result) => cdr]
-                                   [else 0])))])
-            (and (= (length expected) (hashtable-size result))
-                 (fold-left
-                   (lambda (count-agrees w.c)
-                     (and count-agrees
-                          (= (cdr w.c) (get-count (car w.c)))))
-                   #t
-                   expected))))
+      (test-success "multiple spaces not detected as a word" matches?
         word-count '(" multiple   whitespaces")
         '(("multiple" . 1) ("whitespaces" . 1))))
     (lambda ()
-      (test-success "alternating word separators not detected as a word"
-        (lambda (result expected)
-          (let ([get-count (if (hashtable? result)
-                               (lambda (word)
-                                 (hashtable-ref result word 0))
-                               (lambda (word)
-                                 (cond
-                                   [(assoc word result) => cdr]
-                                   [else 0])))])
-            (and (= (length expected) (hashtable-size result))
-                 (fold-left
-                   (lambda (count-agrees w.c)
-                     (and count-agrees
-                          (= (cdr w.c) (get-count (car w.c)))))
-                   #t
-                   expected))))
+      (test-success "alternating word separators not detected as a word" matches?
         word-count '(",\n,one,\n ,two \n 'three'")
         '(("one" . 1) ("two" . 1) ("three" . 1))))))
 
@@ -376,4 +198,3 @@
      (load "word-count.scm")
      (run-docker test-cases)]
     [else (load (cadr args)) (test 'input 'output)]))
-

--- a/exercises/practice/word-count/test.scm
+++ b/exercises/practice/word-count/test.scm
@@ -198,3 +198,4 @@
      (load "word-count.scm")
      (run-docker test-cases)]
     [else (load (cadr args)) (test 'input 'output)]))
+


### PR DESCRIPTION
The 'get-count' procedure defined in each test case's success predicate
allows for alists to be passed as 'results', but the conditional in the
predicate assumes only r6rs hashtables.

Each test case has the same success-predicate passed to 'test-success'
so this patch removes those unnecessary duplicates and moves them into a
new 'matches?' predicate which is passed to each call to 'test-success'.