### PR TITLE
fix armstrong numbers function name to match tests

### DIFF
--- a/exercises/practice/armstrong-numbers/armstrong-numbers.scm
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers.scm
@@ -1,4 +1,4 @@
 (import (rnrs))
 
-(define (armstrong-numbers? n)
+(define (armstrong-number? n)
   'implement-me!)


### PR DESCRIPTION
tests expect this function to be called `armstrong-number?` (singular), this rename fixes that.