### PR TITLE
Rewrite tests for consistency

### DIFF
--- a/exercises/practice/accumulate/Makefile
+++ b/exercises/practice/accumulate/Makefile
@@ -1,0 +1,17 @@
+solution := 
+
+chez := scheme
+guile := guile
+
+help :
+	echo 'Run make chez or make guile'
+
+check-all : chez guile
+
+chez :
+	$(chez) --script test.scm $(solution)
+
+guile :
+	$(guile) test.scm $(solution)
+
+.PHONY : help check-all chez guile

--- a/exercises/practice/accumulate/test.scm
+++ b/exercises/practice/accumulate/test.scm
@@ -1,58 +1,151 @@
-(load "accumulate.scm")
+(import (except (rnrs) current-output-port))
 
-(use-modules (srfi srfi-1)
-             (srfi srfi-13)
-             (srfi srfi-64))
+(define test-fields '(input output))
 
-(define (square n)
-  (* n n))
+(define (test-run-solution solution input)
+  (if (procedure? solution) (apply solution input) solution))
 
-(test-begin "accumulate")
+(define (test-success description success-predicate
+         procedure input output)
+  (call/cc
+    (lambda (k)
+      (let ([out (open-output-string)])
+        (with-exception-handler
+          (lambda (e)
+            (let ([result `(fail
+                             (description . ,description)
+                             (input . ,input)
+                             (output . ,output)
+                             (stdout . ,(get-output-string out)))])
+              (close-output-port out)
+              (k result)))
+          (lambda ()
+            (let ([result (parameterize ([current-output-port out])
+                            (test-run-solution procedure input))])
+              (unless (success-predicate result output)
+                (error 'exercism-test
+                  "test fails"
+                  description
+                  input
+                  result
+                  output)))
+            (let ([result `(pass
+                             (description . ,description)
+                             (stdout . ,(get-output-string out)))])
+              (close-output-port out)
+              result)))))))
 
-; (test-skip "empty list")
-(test-equal "empty list"
-  (accumulate identity '()) '())
+(define (test-error description procedure input)
+  (call/cc
+    (lambda (k)
+      (let ([out (open-output-string)])
+        (with-exception-handler
+          (lambda (e)
+            (let ([result `(pass
+                             (description . ,description)
+                             (stdout . ,(get-output-string out)))])
+              (close-output-port out)
+              (k result)))
+          (lambda ()
+            (parameterize ([current-output-port out])
+              (test-run-solution procedure input))
+            (let ([result `(fail
+                             (description . ,description)
+                             (input . ,input)
+                             (output . error)
+                             (stdout . ,(get-output-string out)))])
+              (close-output-port out)
+              result)))))))
 
-(test-skip "identity")
-(test-equal "identity"
-  (accumulate identity '(1 2 3))
-  '(1 2 3))
+(define (run-test-suite tests . query)
+  (for-each
+    (lambda (field)
+      (unless (and (symbol? field) (memq field test-fields))
+        (error 'run-test-suite
+          (format #t "~a not in ~a" field test-fields))))
+    query)
+  (let-values ([(passes failures)
+                (partition
+                  (lambda (result) (eq? 'pass (car result)))
+                  (map (lambda (test) (test)) tests))])
+    (cond
+      [(null? failures) (format #t "~%Well done!~%~%")]
+      [else
+       (format
+         #t
+         "~%Passed ~a/~a tests.~%~%The following test cases failed:~%~%"
+         (length passes)
+         (length tests))
+       (for-each
+         (lambda (failure)
+           (format
+             #t
+             "* ~a~%"
+             (cond
+               [(assoc 'description (cdr failure)) => cdr]
+               [else (cdr failure)]))
+           (for-each
+             (lambda (field)
+               (let ([info (assoc field (cdr failure))])
+                 (display "  - ")
+                 (write (car info))
+                 (display ": ")
+                 (write (cdr info))
+                 (newline)))
+             query))
+         failures)
+       (error 'test "incorrect solution")])))
 
-(test-skip "1+")
-(test-equal "1+"
-  (accumulate 1+ '(1 2 3))
-  '(2 3 4))
+(define (run-docker test-cases)
+  (write (map (lambda (test) (test)) test-cases)))
 
-(test-skip "squares")
-(test-equal "squares"
-  (accumulate square '(1 2 3))
-  '(1 4 9))
+(define (square x) (* x x))
 
-(test-skip "upcases")
-(test-equal "upcases"
-  (accumulate string-upcase '("hello" "world"))
-  '("HELLO" "WORLD"))
+(define accumulate)
 
-(test-skip "reverse strings")
-(test-equal "reverse strings"
-  (accumulate string-reverse '("the" "quick" "brown" "fox" "jumps" "over" "the" "lazy" "dog"))
-  '("eht" "kciuq" "nworb" "xof" "spmuj" "revo" "eht" "yzal" "god"))
+(define test-cases
+  (list
+    (lambda ()
+      (test-success "empty list" equal? accumulate `(,identity ()) '()))
+    (lambda ()
+      (test-success "identity" equal? accumulate `(,identity (1 2 3)) '(1 2 3)))
+    (lambda ()
+      (test-success "1+" equal? accumulate `(,1+ (1 2 3)) '(2 3 4)))
+    (lambda ()
+      (test-success "squares" equal? accumulate `(,square (1 2 3)) '(1 4 9)))
+    (lambda ()
+      (test-success "upcases" equal? accumulate
+                    `(,string-upcase ("hello" "world")) '("HELLO" "WORLD")))
+    (lambda ()
+      (test-success
+        "reverse strings" equal? accumulate
+        `(,string-reverse ("the" "quick" "brown" "fox" "jumps" "over" "the" "lazy" "dog"))
+        '("eht" "kciuq" "nworb" "xof" "spmuj" "revo" "eht" "yzal" "god")))
+    (lambda ()
+      (test-success "length" equal? accumulate
+                    `(,length ((a b c) (((d))) (e (f (g (h)))))) '(3 1 2)))
+    (lambda ()
+      (test-success
+        "accumulate w/in accumulate" equal? accumulate
+        `(,(lambda (x)
+             (string-join
+               (accumulate (lambda (y)
+                             (string-append x y))
+                           '("1" "2" "3"))
+               " "))
+           ("a" "b" "c"))
+        '("a1 a2 a3" "b1 b2 b3" "c1 c2 c3")))))
 
-(test-skip "length")
-(test-equal "length"
-  (accumulate length
-              '((a b c) (((d))) (e (f (g (h))))))
-  '(3 1 2))
+(define (test . query)
+  (apply run-test-suite test-cases query))
 
-(test-skip "accumulate w/in accumulate")
-(test-equal "accumulate w/in accumulate"
-  (accumulate (lambda (x)
-                (string-join
-                 (accumulate (lambda (y)
-                               (string-append x y))
-                             '("1" "2" "3"))
-                 " "))
-              '("a" "b" "c"))
-  '("a1 a2 a3" "b1 b2 b3" "c1 c2 c3"))
+(let ([args (command-line)])
+  (cond
+    [(null? (cdr args))
+     (load "accumulate.scm")
+     (test 'input 'output)]
+    [(string=? (cadr args) "--docker")
+     (load "accumulate.scm")
+     (run-docker test-cases)]
+    [else (load (cadr args)) (test 'input 'output)]))
 
-(test-end "accumulate")

--- a/exercises/practice/acronym/Makefile
+++ b/exercises/practice/acronym/Makefile
@@ -1,0 +1,17 @@
+solution := 
+
+chez := scheme
+guile := guile
+
+help :
+	echo 'Run make chez or make guile'
+
+check-all : chez guile
+
+chez :
+	$(chez) --script test.scm $(solution)
+
+guile :
+	$(guile) test.scm $(solution)
+
+.PHONY : help check-all chez guile

--- a/exercises/practice/acronym/test.scm
+++ b/exercises/practice/acronym/test.scm
@@ -1,57 +1,148 @@
-(load "acronym.scm")
+(import (except (rnrs) current-output-port))
 
-(use-modules (srfi srfi-64))
+(define test-fields '(input output))
 
-(test-begin "acronym")
+(define (test-run-solution solution input)
+  (if (procedure? solution) (apply solution input) solution))
 
-; (test-skip "basic")
-(test-equal "basic"
-  (acronym "Portable Network Graphics")
-  "PNG")
+(define (test-success description success-predicate
+         procedure input output)
+  (call/cc
+    (lambda (k)
+      (let ([out (open-output-string)])
+        (with-exception-handler
+          (lambda (e)
+            (let ([result `(fail
+                             (description . ,description)
+                             (input . ,input)
+                             (output . ,output)
+                             (stdout . ,(get-output-string out)))])
+              (close-output-port out)
+              (k result)))
+          (lambda ()
+            (let ([result (parameterize ([current-output-port out])
+                            (test-run-solution procedure input))])
+              (unless (success-predicate result output)
+                (error 'exercism-test
+                  "test fails"
+                  description
+                  input
+                  result
+                  output)))
+            (let ([result `(pass
+                             (description . ,description)
+                             (stdout . ,(get-output-string out)))])
+              (close-output-port out)
+              result)))))))
 
-(test-skip "lowercase words")
-(test-equal "lowercase words"
-  (acronym "Ruby on Rails")
-  "ROR")
+(define (test-error description procedure input)
+  (call/cc
+    (lambda (k)
+      (let ([out (open-output-string)])
+        (with-exception-handler
+          (lambda (e)
+            (let ([result `(pass
+                             (description . ,description)
+                             (stdout . ,(get-output-string out)))])
+              (close-output-port out)
+              (k result)))
+          (lambda ()
+            (parameterize ([current-output-port out])
+              (test-run-solution procedure input))
+            (let ([result `(fail
+                             (description . ,description)
+                             (input . ,input)
+                             (output . error)
+                             (stdout . ,(get-output-string out)))])
+              (close-output-port out)
+              result)))))))
 
-(test-skip "punctuation")
-(test-equal "punctuation"
-  (acronym "First In, First Out")
-  "FIFO")
+(define (run-test-suite tests . query)
+  (for-each
+    (lambda (field)
+      (unless (and (symbol? field) (memq field test-fields))
+        (error 'run-test-suite
+          (format #t "~a not in ~a" field test-fields))))
+    query)
+  (let-values ([(passes failures)
+                (partition
+                  (lambda (result) (eq? 'pass (car result)))
+                  (map (lambda (test) (test)) tests))])
+    (cond
+      [(null? failures) (format #t "~%Well done!~%~%")]
+      [else
+       (format
+         #t
+         "~%Passed ~a/~a tests.~%~%The following test cases failed:~%~%"
+         (length passes)
+         (length tests))
+       (for-each
+         (lambda (failure)
+           (format
+             #t
+             "* ~a~%"
+             (cond
+               [(assoc 'description (cdr failure)) => cdr]
+               [else (cdr failure)]))
+           (for-each
+             (lambda (field)
+               (let ([info (assoc field (cdr failure))])
+                 (display "  - ")
+                 (write (car info))
+                 (display ": ")
+                 (write (cdr info))
+                 (newline)))
+             query))
+         failures)
+       (error 'test "incorrect solution")])))
 
-(test-skip "all caps words")
-(test-equal "all caps word"
-  (acronym "GNU Image Manipulation Program")
-  "GIMP")
+(define (run-docker test-cases)
+  (write (map (lambda (test) (test)) test-cases)))
 
-(test-skip "colon")
-(test-equal "colon"
-  (acronym "PHP: Hypertext Preprocessor")
-  "PHP")
+(define acronym)
 
-(test-skip "punctuation without whitespace")
-(test-equal "punctuation without whitespace"
-  (acronym "Complementary metal-oxide semiconductor")
-  "CMOS")
+(define test-cases
+  (list
+    (lambda ()
+      (test-success "basic" equal? acronym '("Portable Network Graphics") "PNG"))
+    (lambda ()
+      (test-success "lowercase words" equal? acronym '("Ruby on Rails") "ROR"))
+    (lambda ()
+      (test-success "punctuation" equal? acronym '("First In, First Out") "FIFO"))
+    (lambda ()
+      (test-success
+        "all caps word" equal? acronym '("GNU Image Manipulation Program") "GIMP"))
+    (lambda ()
+      (test-success "colon" equal? acronym '("PHP: Hypertext Preprocessor") "PHP"))
+    (lambda ()
+      (test-success
+        "punctuation without whitespace" equal? acronym
+        '("Complementary metal-oxide semiconductor") "CMOS"))
+    (lambda ()
+      (test-success
+        "very long abbreviation" equal? acronym
+        '("Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me")
+        "ROTFLSHTMDCOALM"))
+    (lambda ()
+      (test-success
+        "consecutive delimiters" equal? acronym
+        '("Something - I made up from thin air") "SIMUFTA"))
+    (lambda ()
+      (test-success "apostrophes" equal? acronym '("Halley's Comet") "HC"))
+    (lambda ()
+      (test-success
+        "underscore emphasis" equal? acronym '("The Road _Not_ Taken") "TRNT"))))
 
-(test-skip "very long abbreviation")
-(test-equal "very long abbreviation"
-  (acronym "Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me")
-  "ROTFLSHTMDCOALM")
+(define (test . query)
+  (apply run-test-suite test-cases query))
 
-(test-skip "consecutive delimiters")
-(test-equal "consecutive delimiters"
-  (acronym "Something - I made up from thin air")
-  "SIMUFTA")
+(let ([args (command-line)])
+  (cond
+    [(null? (cdr args))
+     (load "acronym.scm")
+     (test 'input 'output)]
+    [(string=? (cadr args) "--docker")
+     (load "acronym.scm")
+     (run-docker test-cases)]
+    [else (load (cadr args)) (test 'input 'output)]))
 
-(test-skip "apostrophes")
-(test-equal "apostrophes"
-  (acronym "Halley's Comet")
-  "HC")
-
-(test-skip "underscore emphasis")
-(test-equal "underscore emphasis"
-  (acronym "The Road _Not_ Taken")
-  "TRNT")
-
-(test-end "acronym")

--- a/exercises/practice/armstrong-numbers/Makefile
+++ b/exercises/practice/armstrong-numbers/Makefile
@@ -1,0 +1,17 @@
+solution := 
+
+chez := scheme
+guile := guile
+
+help :
+	echo 'Run make chez or make guile'
+
+check-all : chez guile
+
+chez :
+	$(chez) --script test.scm $(solution)
+
+guile :
+	$(guile) test.scm $(solution)
+
+.PHONY : help check-all chez guile

--- a/exercises/practice/octal/Makefile
+++ b/exercises/practice/octal/Makefile
@@ -1,0 +1,17 @@
+solution := 
+
+chez := scheme
+guile := guile
+
+help :
+	echo 'Run make chez or make guile'
+
+check-all : chez guile
+
+chez :
+	$(chez) --script test.scm $(solution)
+
+guile :
+	$(guile) test.scm $(solution)
+
+.PHONY : help check-all chez guile

--- a/exercises/practice/roman-numerals/Makefile
+++ b/exercises/practice/roman-numerals/Makefile
@@ -1,0 +1,17 @@
+solution := 
+
+chez := scheme
+guile := guile
+
+help :
+	echo 'Run make chez or make guile'
+
+check-all : chez guile
+
+chez :
+	$(chez) --script test.scm $(solution)
+
+guile :
+	$(guile) test.scm $(solution)
+
+.PHONY : help check-all chez guile

--- a/exercises/practice/roman-numerals/test.scm
+++ b/exercises/practice/roman-numerals/test.scm
@@ -1,147 +1,180 @@
-(load "roman-numerals.scm")
+(import (except (rnrs) current-output-port))
 
-(use-modules (srfi srfi-64))
+(define test-fields '(input output))
 
-(test-begin "roman-numerals")
+(define (test-run-solution solution input)
+  (if (procedure? solution) (apply solution input) solution))
 
-; (test-skip "1 is a single I")
-(test-equal "1 is a single I"
-  (roman 1)
-  "I")
+(define (test-success description success-predicate
+         procedure input output)
+  (call/cc
+    (lambda (k)
+      (let ([out (open-output-string)])
+        (with-exception-handler
+          (lambda (e)
+            (let ([result `(fail
+                             (description . ,description)
+                             (input . ,input)
+                             (output . ,output)
+                             (stdout . ,(get-output-string out)))])
+              (close-output-port out)
+              (k result)))
+          (lambda ()
+            (let ([result (parameterize ([current-output-port out])
+                            (test-run-solution procedure input))])
+              (unless (success-predicate result output)
+                (error 'exercism-test
+                  "test fails"
+                  description
+                  input
+                  result
+                  output)))
+            (let ([result `(pass
+                             (description . ,description)
+                             (stdout . ,(get-output-string out)))])
+              (close-output-port out)
+              result)))))))
 
-(test-skip "2 is two I's")
-(test-equal "2 is two I's"
-  (roman 2)
-  "II")
+(define (test-error description procedure input)
+  (call/cc
+    (lambda (k)
+      (let ([out (open-output-string)])
+        (with-exception-handler
+          (lambda (e)
+            (let ([result `(pass
+                             (description . ,description)
+                             (stdout . ,(get-output-string out)))])
+              (close-output-port out)
+              (k result)))
+          (lambda ()
+            (parameterize ([current-output-port out])
+              (test-run-solution procedure input))
+            (let ([result `(fail
+                             (description . ,description)
+                             (input . ,input)
+                             (output . error)
+                             (stdout . ,(get-output-string out)))])
+              (close-output-port out)
+              result)))))))
 
-(test-skip "3 is three I's")
-(test-equal "3 is three I's"
-  (roman 3)
-  "III")
+(define (run-test-suite tests . query)
+  (for-each
+    (lambda (field)
+      (unless (and (symbol? field) (memq field test-fields))
+        (error 'run-test-suite
+          (format #t "~a not in ~a" field test-fields))))
+    query)
+  (let-values ([(passes failures)
+                (partition
+                  (lambda (result) (eq? 'pass (car result)))
+                  (map (lambda (test) (test)) tests))])
+    (cond
+      [(null? failures) (format #t "~%Well done!~%~%")]
+      [else
+       (format
+         #t
+         "~%Passed ~a/~a tests.~%~%The following test cases failed:~%~%"
+         (length passes)
+         (length tests))
+       (for-each
+         (lambda (failure)
+           (format
+             #t
+             "* ~a~%"
+             (cond
+               [(assoc 'description (cdr failure)) => cdr]
+               [else (cdr failure)]))
+           (for-each
+             (lambda (field)
+               (let ([info (assoc field (cdr failure))])
+                 (display "  - ")
+                 (write (car info))
+                 (display ": ")
+                 (write (cdr info))
+                 (newline)))
+             query))
+         failures)
+       (error 'test "incorrect solution")])))
 
-(test-skip "4, being 5 - 1, is IV")
-(test-equal "4, being 5 - 1, is IV"
-  (roman 4)
-  "IV")
+(define (run-docker test-cases)
+  (write (map (lambda (test) (test)) test-cases)))
 
-(test-skip "5 is a single V")
-(test-equal "5 is a single V"
-  (roman 5)
-  "V")
+(define roman)
 
-(test-skip "6, being 5 + 1, is VI")
-(test-equal "6, being 5 + 1, is VI"
-  (roman 6)
-  "VI")
+(define test-cases
+  (list
+    (lambda ()
+      (test-success "1 is a single I" equal? roman '(1) "I"))
+    (lambda ()
+      (test-success "2 is two I's" equal? roman '(2) "II"))
+    (lambda ()
+      (test-success "3 is three I's" equal? roman '(3) "III"))
+    (lambda ()
+      (test-success "4, being 5 - 1, is IV" equal? roman '(4) "IV"))
+    (lambda ()
+      (test-success "5 is a single V" equal? roman '(5) "V"))
+    (lambda ()
+      (test-success "6, being 5 + 1, is VI" equal? roman '(6) "VI"))
+    (lambda ()
+      (test-success "9, being 10 - 1, is IX" equal? roman '(9) "IX"))
+    (lambda ()
+      (test-success "20 is two X's" equal? roman '(20) "XX"))
+    (lambda ()
+      (test-success "27 is 10 + 10 + 5 + 1 + 1" equal? roman '(27) "XXVII"))
+    (lambda ()
+      (test-success "48 is not 50 - 2 but rather 40 + 8" equal? roman
+                    '(48) "XLVIII"))
+    (lambda ()
+      (test-success "49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1" equal?
+                    roman '(49) "XLIX"))
+    (lambda ()
+      (test-success "50 is a single L" equal? roman '(50) "L"))
+    (lambda ()
+      (test-success "59 is 50 + 10 - 1" equal? roman '(59) "LIX"))
+    (lambda ()
+      (test-success "60, being 50 + 10, is LX" equal? roman '(60) "LX"))
+    (lambda ()
+      (test-success "90, being 100 - 10, is XC" equal? roman '(90) "XC"))
+    (lambda ()
+      (test-success "93 is 100 - 10 + 1 + 1 + 1" equal? roman '(93) "XCIII"))
+    (lambda ()
+      (test-success "100 is a single C" equal? roman '(100) "C"))
+    (lambda ()
+      (test-success "141 is 100 + 50 - 10 + 1" equal? roman '(141) "CXLI"))
+    (lambda ()
+      (test-success "163 is 100 + 50 + 10 + 1 + 1 + 1" equal? roman
+                    '(163) "CLXIII"))
+    (lambda ()
+      (test-success "400, being 500 - 100, is CD" equal? roman '(400) "CD"))
+    (lambda ()
+      (test-success "402 is 500 - 100 + 2" equal? roman '(402) "CDII"))
+    (lambda ()
+      (test-success "500 is a single D" equal? roman '(500) "D"))
+    (lambda ()
+      (test-success "575 is 500 + 50 + 10 + 10 + 5" equal? roman
+                    '(575) "DLXXV"))
+    (lambda ()
+      (test-success "900, being 1000 - 100, is CM" equal? roman '(900) "CM"))
+    (lambda ()
+      (test-success "911 is 1000 - 100 + 10 + 1" equal? roman '(911) "CMXI"))
+    (lambda ()
+      (test-success "1000 is a single M" equal? roman '(1000) "M"))
+    (lambda ()
+      (test-success "1024 is 1000 + 10 + 10 + 5 - 1" equal? roman
+                    '(1024) "MXXIV"))
+    (lambda ()
+      (test-success "3000 is three M's" equal? roman '(3000) "MMM"))))
 
-(test-skip "9, being 10 - 1, is IX")
-(test-equal "9, being 10 - 1, is IX"
-  (roman 9)
-  "IX")
+(define (test . query)
+  (apply run-test-suite test-cases query))
 
-(test-skip "20 is two X's")
-(test-equal "20 is two X's"
-  (roman 20)
-  "XX")
+(let ([args (command-line)])
+  (cond
+    [(null? (cdr args))
+     (load "roman-numerals.scm")
+     (test 'input 'output)]
+    [(string=? (cadr args) "--docker")
+     (load "roman-numerals.scm")
+     (run-docker test-cases)]
+    [else (load (cadr args)) (test 'input 'output)]))
 
-(test-skip "27 is 10 + 10 + 5 + 1 + 1")
-(test-equal "27 is 10 + 10 + 5 + 1 + 1"
-  (roman 27)
-  "XXVII")
-
-(test-skip "48 is not 50 - 2 but rather 40 + 8")
-(test-equal "48 is not 50 - 2 but rather 40 + 8"
-  (roman 48)
-  "XLVIII")
-
-(test-skip "49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1")
-(test-equal "49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1"
-  (roman 49)
-  "XLIX")
-
-(test-skip "50 is a single L")
-(test-equal "50 is a single L"
-  (roman 50)
-  "L")
-
-(test-skip "59 is 50 + 10 - 1")
-(test-equal "59 is 50 + 10 - 1"
-  (roman 59)
-  "LIX")
-
-(test-skip "60, being 50 + 10, is LX")
-(test-equal "60, being 50 + 10, is LX"
-  (roman 60)
-  "LX")
-
-(test-skip "90, being 100 - 10, is XC")
-(test-equal "90, being 100 - 10, is XC"
-  (roman 90)
-  "XC")
-
-(test-skip "93 is 100 - 10 + 1 + 1 + 1")
-(test-equal "93 is 100 - 10 + 1 + 1 + 1"
-  (roman 93)
-  "XCIII")
-
-(test-skip "100 is a single C")
-(test-equal "100 is a single C"
-  (roman 100)
-  "C")
-
-(test-skip "141 is 100 + 50 - 10 + 1")
-(test-equal "141 is 100 + 50 - 10 + 1"
-  (roman 141)
-  "CXLI")
-
-(test-skip "163 is 100 + 50 + 10 + 1 + 1 + 1")
-(test-equal "163 is 100 + 50 + 10 + 1 + 1 + 1"
-  (roman 163)
-  "CLXIII")
-
-(test-skip "400, being 500 - 100, is CD")
-(test-equal "400, being 500 - 100, is CD"
-  (roman 400)
-  "CD")
-
-(test-skip "402 is 500 - 100 + 2")
-(test-equal "402 is 500 - 100 + 2"
-  (roman 402)
-  "CDII")
-
-(test-skip "500 is a single D")
-(test-equal "500 is a single D"
-  (roman 500)
-  "D")
-
-(test-skip "575 is 500 + 50 + 10 + 10 + 5")
-(test-equal "575 is 500 + 50 + 10 + 10 + 5"
-  (roman 575)
-  "DLXXV")
-
-(test-skip "900, being 1000 - 100, is CM")
-(test-equal "900, being 1000 - 100, is CM"
-  (roman 900)
-  "CM")
-
-(test-skip "911 is 1000 - 100 + 10 + 1")
-(test-equal "911 is 1000 - 100 + 10 + 1"
-  (roman 911)
-  "CMXI")
-
-(test-skip "1000 is a single M")
-(test-equal "1000 is a single M"
-  (roman 1000)
-  "M")
-
-(test-skip "1024 is 1000 + 10 + 10 + 5 - 1")
-(test-equal "1024 is 1000 + 10 + 10 + 5 - 1"
-  (roman 1024)
-  "MXXIV")
-
-(test-skip "3000 is three M's")
-(test-equal "3000 is three M's"
-  (roman 3000)
-  "MMM")
-
-(test-end "roman-numerals")

--- a/exercises/practice/strain/test.scm
+++ b/exercises/practice/strain/test.scm
@@ -1,4 +1,103 @@
-(load "strain.scm")
+(import (except (rnrs) current-output-port))
+
+(define test-fields '(input output))
+
+(define (test-run-solution solution input)
+  (if (procedure? solution) (apply solution input) solution))
+
+(define (test-success description success-predicate
+         procedure input output)
+  (call/cc
+    (lambda (k)
+      (let ([out (open-output-string)])
+        (with-exception-handler
+          (lambda (e)
+            (let ([result `(fail
+                             (description . ,description)
+                             (input . ,input)
+                             (output . ,output)
+                             (stdout . ,(get-output-string out)))])
+              (close-output-port out)
+              (k result)))
+          (lambda ()
+            (let ([result (parameterize ([current-output-port out])
+                            (test-run-solution procedure input))])
+              (unless (success-predicate result output)
+                (error 'exercism-test
+                  "test fails"
+                  description
+                  input
+                  result
+                  output)))
+            (let ([result `(pass
+                             (description . ,description)
+                             (stdout . ,(get-output-string out)))])
+              (close-output-port out)
+              result)))))))
+
+(define (test-error description procedure input)
+  (call/cc
+    (lambda (k)
+      (let ([out (open-output-string)])
+        (with-exception-handler
+          (lambda (e)
+            (let ([result `(pass
+                             (description . ,description)
+                             (stdout . ,(get-output-string out)))])
+              (close-output-port out)
+              (k result)))
+          (lambda ()
+            (parameterize ([current-output-port out])
+              (test-run-solution procedure input))
+            (let ([result `(fail
+                             (description . ,description)
+                             (input . ,input)
+                             (output . error)
+                             (stdout . ,(get-output-string out)))])
+              (close-output-port out)
+              result)))))))
+
+(define (run-test-suite tests . query)
+  (for-each
+    (lambda (field)
+      (unless (and (symbol? field) (memq field test-fields))
+        (error 'run-test-suite
+          (format #t "~a not in ~a" field test-fields))))
+    query)
+  (let-values ([(passes failures)
+                (partition
+                  (lambda (result) (eq? 'pass (car result)))
+                  (map (lambda (test) (test)) tests))])
+    (cond
+      [(null? failures) (format #t "~%Well done!~%~%")]
+      [else
+       (format
+         #t
+         "~%Passed ~a/~a tests.~%~%The following test cases failed:~%~%"
+         (length passes)
+         (length tests))
+       (for-each
+         (lambda (failure)
+           (format
+             #t
+             "* ~a~%"
+             (cond
+               [(assoc 'description (cdr failure)) => cdr]
+               [else (cdr failure)]))
+           (for-each
+             (lambda (field)
+               (let ([info (assoc field (cdr failure))])
+                 (display "  - ")
+                 (write (car info))
+                 (display ": ")
+                 (write (cdr info))
+                 (newline)))
+             query))
+         failures)
+       (error 'test "incorrect solution")])))
+
+(define (run-docker test-cases)
+  (write (map (lambda (test) (test)) test-cases)))
 
 (define (under-10? n)
   (< n 10))
@@ -6,68 +105,58 @@
 (define (starts-with-z? s)
   (char=? (string-ref s 0) #\z))
 
-(use-modules (srfi srfi-64))
+(define keep)
+(define discard)
 
-(test-begin "strain")
+(define test-cases
+  (list
+    (lambda ()
+      (test-success "empty keep" equal? keep `(,under-10? ()) '()))
+    (lambda ()
+      (test-success "keep everything" equal? keep
+                    `(,under-10? (0 2 4 6 8)) '(0 2 4 6 8)))
+    (lambda ()
+      (test-success "keep first last" equal? keep `(,odd? (1 2 3)) '(1 3)))
+    (lambda ()
+      (test-success "keep nothing" equal? keep `(,even? (1 3 5 7 9)) '()))
+    (lambda ()
+      (test-success "keep neither first nor last" equal? keep
+                    `(,even? (1 2 3)) '(2)))
+    (lambda ()
+      (test-success
+        "keep strings" equal? keep
+        `(,starts-with-z? ("apple" "zebra" "banana" "zombies" "cherimoya" "zealot"))
+        '("zebra" "zombies" "zealot")))
+    (lambda ()
+      (test-success "empty discard" equal? discard `(,under-10? ()) '()))
+    (lambda ()
+      (test-success "discard everything" equal? discard
+                    `(,under-10? (1 2 3)) '()))
+    (lambda ()
+      (test-success "discard first and last" equal? discard
+                    `(,odd? (1 2 3)) '(2)))
+    (lambda ()
+      (test-success "discard nothing" equal? discard
+                    `(,even? (1 3 5 7 9)) '(1 3 5 7 9)))
+    (lambda ()
+      (test-success "discard neither first nor last" equal? discard
+                    `(,even? (1 2 3)) '(1 3)))
+    (lambda ()
+      (test-success
+        "discard strings" equal? discard
+        `(,starts-with-z? ("apple" "zebra" "banana" "zombies" "cherimoya" "zealot"))
+        '("apple" "banana" "cherimoya")))))
 
-; (test-skip "empty keep")
-(test-equal "empty keep"
-  (keep under-10? '())
-  '())
+(define (test . query)
+  (apply run-test-suite test-cases query))
 
-(test-skip "keep everything")
-(test-equal "keep everything"
-  (keep under-10? '(0 2 4 6 8))
-  '(0 2 4 6 8))
+(let ([args (command-line)])
+  (cond
+    [(null? (cdr args))
+     (load "strain.scm")
+     (test 'input 'output)]
+    [(string=? (cadr args) "--docker")
+     (load "strain.scm")
+     (run-docker test-cases)]
+    [else (load (cadr args)) (test 'input 'output)]))
 
-(test-skip "keep first last")
-(test-equal "keep first last"
-  (keep odd? '(1 2 3))
-  '(1 3))
-
-(test-skip "keep nothing")
-(test-equal "keep nothing"
-  (keep even? '(1 3 5 7 9))
-  '())
-
-(test-skip "keep neither first nor last")
-(test-equal "keep neither first nor last"
-  (keep even? '(1 2 3))
-  '(2))
-
-(test-skip "keep strings")
-(test-equal "keep strings"
-  (keep starts-with-z? '("apple" "zebra" "banana" "zombies" "cherimoya" "zealot"))
-  '("zebra" "zombies" "zealot"))
-
-(test-skip "empty discard")
-(test-equal "empty discard"
-  (discard under-10? '())
-  '())
-
-(test-skip "discard everything")
-(test-equal "discard everything"
-  (discard under-10? '(1 2 3))
-  '())
-
-(test-skip "discard first and last")
-(test-equal "discard first and last"
-  (discard odd? '(1 2 3))
-  '(2))
-
-(test-skip "discard nothing")
-(test-equal "discard nothing"
-  (discard even? '(1 3 5 7 9))
-  '(1 3 5 7 9))
-
-(test-skip "discard neither first nor last")
-(test-equal "discard neither first nor last"
-  (discard even? '(1 2 3))
-  '(1 3))
-
-(test-skip "discard strings")
-(test-equal "discard strings"
-  (discard starts-with-z? '("apple" "zebra" "banana" "zombies" "cherimoya" "zealot"))
-  '("apple" "banana" "cherimoya"))
-
-(test-end "strain")

--- a/exercises/practice/sum-of-multiples/Makefile
+++ b/exercises/practice/sum-of-multiples/Makefile
@@ -1,0 +1,17 @@
+solution := 
+
+chez := scheme
+guile := guile
+
+help :
+	echo 'Run make chez or make guile'
+
+check-all : chez guile
+
+chez :
+	$(chez) --script test.scm $(solution)
+
+guile :
+	$(guile) test.scm $(solution)
+
+.PHONY : help check-all chez guile

--- a/exercises/practice/triangle/Makefile
+++ b/exercises/practice/triangle/Makefile
@@ -1,0 +1,17 @@
+solution := 
+
+chez := scheme
+guile := guile
+
+help :
+	echo 'Run make chez or make guile'
+
+check-all : chez guile
+
+chez :
+	$(chez) --script test.scm $(solution)
+
+guile :
+	$(guile) test.scm $(solution)
+
+.PHONY : help check-all chez guile

--- a/exercises/practice/triangle/test.scm
+++ b/exercises/practice/triangle/test.scm
@@ -1,84 +1,145 @@
-(load "triangle.scm")
+(import (except (rnrs) current-output-port))
 
-(use-modules (srfi srfi-64))
+(define test-fields '(input output))
 
-(test-begin "triangle")
+(define (test-run-solution solution input)
+  (if (procedure? solution) (apply solution input) solution))
 
-(test-begin "equilateral")
+(define (test-success description success-predicate
+         procedure input output)
+  (call/cc
+    (lambda (k)
+      (let ([out (open-output-string)])
+        (with-exception-handler
+          (lambda (e)
+            (let ([result `(fail
+                             (description . ,description)
+                             (input . ,input)
+                             (output . ,output)
+                             (stdout . ,(get-output-string out)))])
+              (close-output-port out)
+              (k result)))
+          (lambda ()
+            (let ([result (parameterize ([current-output-port out])
+                            (test-run-solution procedure input))])
+              (unless (success-predicate result output)
+                (error 'exercism-test
+                  "test fails"
+                  description
+                  input
+                  result
+                  output)))
+            (let ([result `(pass
+                             (description . ,description)
+                             (stdout . ,(get-output-string out)))])
+              (close-output-port out)
+              result)))))))
 
-; (test-skip "equilateral: 2 2 2")
-(test-eq "equilateral: 2 2 2"
-  (triangle 2 2 2)
-  'equilateral)
+(define (test-error description procedure input)
+  (call/cc
+    (lambda (k)
+      (let ([out (open-output-string)])
+        (with-exception-handler
+          (lambda (e)
+            (let ([result `(pass
+                             (description . ,description)
+                             (stdout . ,(get-output-string out)))])
+              (close-output-port out)
+              (k result)))
+          (lambda ()
+            (parameterize ([current-output-port out])
+              (test-run-solution procedure input))
+            (let ([result `(fail
+                             (description . ,description)
+                             (input . ,input)
+                             (output . error)
+                             (stdout . ,(get-output-string out)))])
+              (close-output-port out)
+              result)))))))
 
-(test-skip "equilateral: 10 10 10")
-(test-eq "equilateral: 10 10 10"
-  (triangle 10 10 10)
-  'equilateral)
+(define (run-test-suite tests . query)
+  (for-each
+    (lambda (field)
+      (unless (and (symbol? field) (memq field test-fields))
+        (error 'run-test-suite
+          (format #t "~a not in ~a" field test-fields))))
+    query)
+  (let-values ([(passes failures)
+                (partition
+                  (lambda (result) (eq? 'pass (car result)))
+                  (map (lambda (test) (test)) tests))])
+    (cond
+      [(null? failures) (format #t "~%Well done!~%~%")]
+      [else
+       (format
+         #t
+         "~%Passed ~a/~a tests.~%~%The following test cases failed:~%~%"
+         (length passes)
+         (length tests))
+       (for-each
+         (lambda (failure)
+           (format
+             #t
+             "* ~a~%"
+             (cond
+               [(assoc 'description (cdr failure)) => cdr]
+               [else (cdr failure)]))
+           (for-each
+             (lambda (field)
+               (let ([info (assoc field (cdr failure))])
+                 (display "  - ")
+                 (write (car info))
+                 (display ": ")
+                 (write (cdr info))
+                 (newline)))
+             query))
+         failures)
+       (error 'test "incorrect solution")])))
 
-(test-end "equilateral")
+(define (run-docker test-cases)
+  (write (map (lambda (test) (test)) test-cases)))
 
-(test-begin "isosceles")
+(define triangle)
 
-(test-skip "isosceles: 3 4 4")
-(test-eq "isosceles: 3 4 4"
-  (triangle 3 4 4)
-  'isosceles)
+(define test-cases
+  (list
+    (lambda ()
+      (test-success "equilateral: 2 2 2" equal? triangle '(2 2 2) 'equilateral))
+    (lambda ()
+      (test-success "equilateral: 10 10 10" equal? triangle '(10 10 10) 'equilateral))
+    (lambda ()
+      (test-success "isosceles: 3 4 4" equal? triangle '(3 4 4) 'isosceles))
+    (lambda ()
+      (test-success "isosceles: 4 3 4" equal? triangle '(4 3 4) 'isosceles))
+    (lambda ()
+      (test-success "isosceles: 4 4 3" equal? triangle '(4 4 3) 'isosceles))
+    (lambda ()
+      (test-success "isosceles: 10 10 2" equal? triangle '(10 10 2) 'isosceles))
+    (lambda ()
+      (test-success "scalene: 3 4 5" equal? triangle '(3 4 5) 'scalene))
+    (lambda ()
+      (test-success "scalene: 10 11 12" equal? triangle '(10 11 12) 'scalene))
+    (lambda ()
+      (test-success "scalene: 5 4 2" equal? triangle '(5 4 2) 'scalene))
+    (lambda ()
+      (test-error "invalid: 0 0 0" triangle '(0 0 0)))
+    (lambda ()
+      (test-error "invalid: 3 4 -5" triangle '(3 4 -5)))
+    (lambda ()
+      (test-error "invalid: 1 1 3" triangle '(1 1 3)))
+    (lambda ()
+      (test-error "invalid: 2 4 2" triangle '(2 4 2)))))
 
-(test-skip "isosceles: 4 3 4")
-(test-eq "isosceles: 4 3 4"
-  (triangle 4 3 4)
-  'isosceles)
+(define (test . query)
+  (apply run-test-suite test-cases query))
 
-(test-skip "isosceles: 4 4 3")
-(test-eq "isosceles: 4 4 3"
-  (triangle 4 4 3)
-  'isosceles)
+(let ([args (command-line)])
+  (cond
+    [(null? (cdr args))
+     (load "triangle.scm")
+     (test 'input 'output)]
+    [(string=? (cadr args) "--docker")
+     (load "triangle.scm")
+     (run-docker test-cases)]
+    [else (load (cadr args)) (test 'input 'output)]))
 
-(test-skip "isosceles: 10 10 2")
-(test-eq "isosceles: 10 10 2"
-  (triangle 10 10 2)
-  'isosceles)
-
-(test-end "isosceles")
-
-(test-begin "scalene")
-
-(test-skip "scalene: 3 4 5")
-(test-eq "scalene: 3 4 5"
-  (triangle 3 4 5)
-  'scalene)
-
-(test-skip "scalene: 10 11 12")
-(test-eq "scalene: 10 11 12"
-  (triangle 10 11 12)
-  'scalene)
-
-(test-skip "scalene: 5 4 2")
-(test-eq "scalene: 5 4 2"
-  (triangle 5 4 2)
-  'scalene)
-
-(test-end "scalene")
-
-(test-begin "invalid")
-
-(test-skip "invalid: 0 0 0")
-(test-error "invalid: 0 0 0" #t
-            (triangle 0 0 0))
-
-(test-skip "invalid: 3 4 -5")
-(test-error "invalid: 3 4 -5" #t
-            (triangle 3 4 -5))
-
-(test-skip "invalid: 1 1 3")
-(test-error "invalid: 1 1 3" #t
-            (triangle 1 1 3))
-
-(test-skip "invalid: 2 4 2")
-(test-error "invalid: 2 4 2" #t
-            (triangle 2 4 2))
-
-(test-end "invalid")
-
-(test-end "triangle")

--- a/exercises/practice/trinary/Makefile
+++ b/exercises/practice/trinary/Makefile
@@ -1,0 +1,17 @@
+solution := 
+
+chez := scheme
+guile := guile
+
+help :
+	echo 'Run make chez or make guile'
+
+check-all : chez guile
+
+chez :
+	$(chez) --script test.scm $(solution)
+
+guile :
+	$(guile) test.scm $(solution)
+
+.PHONY : help check-all chez guile


### PR DESCRIPTION
The `test.scm` in these 9 commits I copied over from the remaining exercises and updated to use the same approach. The older versions use SRFI-64 which does not produce the output that [exercism/scheme-test-runner/bin/exercise.ss](https://github.com/exercism/scheme-test-runner/blob/0af6b777ddbb95c034e5a87e6dbe4107c8aec95c/bin/exercise.ss) expects. This will allow more tests to pass on the exercism website.