### PR TITLE
Test fix

### DIFF
--- a/exercises/practice/accumulate/test-util.ss
+++ b/exercises/practice/accumulate/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/acronym/test-util.ss
+++ b/exercises/practice/acronym/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/affine-cipher/test-util.ss
+++ b/exercises/practice/affine-cipher/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/anagram/test-util.ss
+++ b/exercises/practice/anagram/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/armstrong-numbers/test-util.ss
+++ b/exercises/practice/armstrong-numbers/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/atbash-cipher/test-util.ss
+++ b/exercises/practice/atbash-cipher/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/binary-search/test-util.ss
+++ b/exercises/practice/binary-search/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/bob/test-util.ss
+++ b/exercises/practice/bob/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/change/test-util.ss
+++ b/exercises/practice/change/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/collatz-conjecture/test-util.ss
+++ b/exercises/practice/collatz-conjecture/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/difference-of-squares/test-util.ss
+++ b/exercises/practice/difference-of-squares/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/forth/test-util.ss
+++ b/exercises/practice/forth/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/grains/test-util.ss
+++ b/exercises/practice/grains/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/hamming/test-util.ss
+++ b/exercises/practice/hamming/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/hello-world/test-util.ss
+++ b/exercises/practice/hello-world/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/knapsack/test-util.ss
+++ b/exercises/practice/knapsack/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/leap/test-util.ss
+++ b/exercises/practice/leap/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/list-ops/test-util.ss
+++ b/exercises/practice/list-ops/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/matching-brackets/test-util.ss
+++ b/exercises/practice/matching-brackets/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/nucleotide-count/test-util.ss
+++ b/exercises/practice/nucleotide-count/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/octal/test-util.ss
+++ b/exercises/practice/octal/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/pangram/test-util.ss
+++ b/exercises/practice/pangram/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/pascals-triangle/test-util.ss
+++ b/exercises/practice/pascals-triangle/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/perfect-numbers/test-util.ss
+++ b/exercises/practice/perfect-numbers/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/phone-number/test-util.ss
+++ b/exercises/practice/phone-number/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/prime-factors/test-util.ss
+++ b/exercises/practice/prime-factors/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/queen-attack/test-util.ss
+++ b/exercises/practice/queen-attack/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/raindrops/test-util.ss
+++ b/exercises/practice/raindrops/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/rna-transcription/test-util.ss
+++ b/exercises/practice/rna-transcription/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/robot-name/test-util.ss
+++ b/exercises/practice/robot-name/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/roman-numerals/test-util.ss
+++ b/exercises/practice/roman-numerals/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/rotational-cipher/test-util.ss
+++ b/exercises/practice/rotational-cipher/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/scrabble-score/test-util.ss
+++ b/exercises/practice/scrabble-score/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/sieve/test-util.ss
+++ b/exercises/practice/sieve/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/strain/test-util.ss
+++ b/exercises/practice/strain/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/sum-of-multiples/test-util.ss
+++ b/exercises/practice/sum-of-multiples/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/transpose/test-util.ss
+++ b/exercises/practice/transpose/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/triangle/test-util.ss
+++ b/exercises/practice/triangle/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/trinary/test-util.ss
+++ b/exercises/practice/trinary/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/two-fer/test-util.ss
+++ b/exercises/practice/two-fer/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/exercises/practice/word-count/test-util.ss
+++ b/exercises/practice/word-count/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)

--- a/input/test-util.ss
+++ b/input/test-util.ss
@@ -16,8 +16,9 @@
         ,(if (who-condition? e) (condition-who e)
              'unknown)
         ,(condition-message e)
-        ,@(if (not (irritants-condition? e)) '()
-              (condition-irritants e)))))
+        ,@(map scheme->string
+               (if (not (irritants-condition? e)) '()
+                   (condition-irritants e))))))
 
 (define (test-success description success-predicate
                       procedure input expected code)


### PR DESCRIPTION
Currently, non-deserializable objects can be serialized in errors reported to the test runner.  This breaks the test runner's ability to report meaningful results to the user.  See exercism/scheme-test-runner#37 for more details.

This simply converts all condition irritants for a given error to strings to ensure this doesn't happen.  I made the changes to `input/test-util.ss` separately from mass-updating all of the `test-util.ss` files expecting the two commit to get squashed.