### PR TITLE
Make failed tests detectable to the Actions runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,11 +97,13 @@ track : $(track-requirements)
 
 # send a list of implementations to run stub-makefile tests on
 ci :
-	#echo "(run-ci '($(implementations)))" | $(chez) -q "script/ci.ss"
+	@#echo "(run-ci '($(implementations)))" | $(chez) -q "script/ci.ss"
 	# The acronym example code only works for guile.  Currently, examples
 	# must pass for both chez and guile.  list-ops and robot-name are both
 	# deprecated anyway.
-	echo "(run-all-tests 'list-ops 'robot-name 'acronym)" | $(chez) -q script/ci.ss
+	echo "(run-all-tests 'list-ops 'robot-name 'acronym)" | $(chez) -q script/ci.ss > build.log
+	@cat build.log
+	(test $$(grep -Ec "(test cases failed:)" build.log) -eq 0)
 
 clean :
 	find . -name "*.so" -exec rm {} \;


### PR DESCRIPTION
Until now, the 'ci' task always exited with 0 because the only command it actually issued was 'echo', which always succeeds.

This adds a final command with a pass/fail exit condition, while also separating error output from standard output, redirecting the latter to a 'build.log' file (which matches an existing ignore rule).

The redirection is a bit of a hack, but necessary given the quirks of the '$(shell ...)' function, which must be given the name of an executable command, disqualifying 'effectful' commands that only print messages.

Fixes #284