### PR TITLE
Update GHA badges in README

### DIFF
--- a/README
+++ b/README
@@ -3,8 +3,7 @@
 #+TITLE: Exercism Scheme Track
 #+AUTHOR: Jason Lewis
 
-[![Configlet](https://github.com/exercism/scheme/actions/workflows/configlet.yml/badge.svg)](https://github.com/exercism/scheme/actions/workflows/configlet.yml)
-[![scheme / main](https://github.com/exercism/scheme/actions/workflows/ci.yml/badge.svg)](https://github.com/exercism/scheme/actions/workflows/ci.yml)
+[[Configlet][https://github.com/exercism/scheme/actions/workflows/configlet.yml/badge.svg]] [[Exercise Tests][https://github.com/exercism/scheme/actions/workflows/ci.yml/badge.svg]]
 
 Exercisms in scheme.
 

--- a/README
+++ b/README
@@ -3,8 +3,8 @@
 #+TITLE: Exercism Scheme Track
 #+AUTHOR: Jason Lewis
 
-[![Configlet Status](https://github.com/exercism/scheme/workflows/configlet/badge.svg)]
-[![Exercise Test Status](https://github.com/exercism/scheme/workflows/scheme%20%2F%20main/badge.svg)]
+[![Configlet](https://github.com/exercism/scheme/actions/workflows/configlet.yml/badge.svg)](https://github.com/exercism/scheme/actions/workflows/configlet.yml)
+[![scheme / main](https://github.com/exercism/scheme/actions/workflows/ci.yml/badge.svg)](https://github.com/exercism/scheme/actions/workflows/ci.yml)
 
 Exercisms in scheme.
 


### PR DESCRIPTION
 I simply copied over the markdown generated by Github to display the badges for the configlet and CI testing actions