### PR TITLE
Add missing learning page entry to docs/config.json

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -8,6 +8,13 @@
       "blurb": "Learn how to install Scheme locally to solve Exercism's exercises on your own machine"
     },
     {
+      "uuid": "d39be63c-89ea-491d-81d5-00d8d0f9bb19",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Scheme",
+      "blurb": "An overview of how to get started from scratch with Scheme"
+    },
+    {
       "uuid": "1528fa64-cf14-4310-a1be-f731c604d34e",
       "slug": "tests",
       "path": "docs/TESTS.md",


### PR DESCRIPTION
@exercism/scheme 

This is related to https://forum.exercism.org/t/404-error-for-scheme-learning-resources/9623/2, but the learning page returns a 404. I noticed there's no entry for that page in docs/config.json so I added one.